### PR TITLE
feat(talk): session persistence — 5-min idle timeout + stop-phrase detection

### DIFF
--- a/docs/superpowers/specs/2026-06-13-talk-session-persistence.md
+++ b/docs/superpowers/specs/2026-06-13-talk-session-persistence.md
@@ -1,0 +1,195 @@
+# Talk Session Persistence — Design
+
+**Date:** 2026-06-13
+**Status:** Approved (brainstorming, Sections 1–4)
+**Scope:** `~/.config/opencode/skills/talk/talk.sh` + `SKILL.md`
+
+## Goal
+
+Make `talk.sh` keep the conversation loop open until the user **explicitly**
+cancels. Today, the 30-second `TALK_IDLE_TIMEOUT_S` and the agent's own
+discipline are the only things keeping the loop alive — both fragile.
+
+After this change, the loop exits only on:
+
+1. **Keyboard** — `Ctrl+C` / `Cmd+D` (caught by `trap`).
+2. **5 minutes of session silence** — bumped `TALK_IDLE_TIMEOUT_S` default
+   (no speech at all in the last 5 min → `cmd_listen` returns empty stdout;
+   the agent re-enters `talk.sh listen` to wait again, but if the user truly
+   walked away, the next 5-min timeout ends the session).
+3. **Spoken "stop talk"** — case-insensitive substring match against
+   `TALK_STOP_PHRASES` (default `"stop talk"`); agent is informed via empty
+   stdout and exits the conversation loop.
+
+## Section 1 — Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ Agent (LLM)                                                      │
+│   while true:                                                    │
+│     out = run("talk.sh speak '<reply>'")   # ← built-in listen    │
+│     if out == "": break        # empty stdout = session ended    │
+│     think(out)                                                    │
+└──────────────────────────────────────────────────────────────────┘
+                │                          ▲
+                │ speak →                  │ next user text on stdout
+                ▼                          │
+┌──────────────────────────────────────────────────────────────────┐
+│ talk.sh  (orchestrator)                                          │
+│   cmd_speak(text):                                               │
+│     1. TTS via tts.sh (Supertonic → NeuTTS → xAI)                │
+│     2. if TALK_AUTO_LISTEN=1: cmd_listen  (auto-loops)           │
+│                                                                  │
+│   cmd_listen():                                                  │
+│     1. Play ready cue                                            │
+│     2. Run vad_recorder.py (idle-timeout = 5 min default)        │
+│     3. Transcribe via Parakeet :5093                             │
+│     4. is_stop_phrase(text)?  → print nothing, return 0          │
+│        else                    → print text, return 0            │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+**Key insight:** the existing `TALK_AUTO_LISTEN=1` default already chains
+`speak` → `listen`. The fix is *only* in `cmd_listen` — bump the timeout
+and add the stop-phrase gate. The outer `while true` in the agent is
+implicit: the agent keeps calling `talk.sh speak` until stdout is empty
+(session ended).
+
+**Why no Python changes:** `vad_recorder.py --idle-timeout-s` already
+exists; the default just changes at the call site.
+
+## Section 2 — Implementation
+
+### Change 1: `talk.sh` line 97 — bump idle timeout default
+
+```bash
+: "${TALK_IDLE_TIMEOUT_S:=30}"
+```
+
+becomes
+
+```bash
+: "${TALK_IDLE_TIMEOUT_S:=300}"
+```
+
+(5 min). Users who want the old behavior set `TALK_IDLE_TIMEOUT_S=30`.
+
+### Change 2: `talk.sh` after line 97 — add stop-phrases env var
+
+```bash
+# Spoken phrases that end the session (case-insensitive substring match,
+# pipe-separated). Default: "stop talk". Spanish example: "para de hablar".
+: "${TALK_STOP_PHRASES:=stop talk}"
+```
+
+### Change 3: `talk.sh` — new `is_stop_phrase()` function + call site
+
+Add helper (sits next to `cmd_ready_cue`, ~line 200):
+
+```bash
+# True if $1 matches any of the | separated phrases in TALK_STOP_PHRASES
+# (case-insensitive substring match).
+is_stop_phrase() {
+    local text="${1,,}"          # bash 4+ lowercase
+    local phrase
+    IFS='|' read -ra phrases <<< "${TALK_STOP_PHRASES,,}"
+    for phrase in "${phrases[@]}"; do
+        [ -z "$phrase" ] && continue
+        [[ "$text" == *"$phrase"* ]] && return 0
+    done
+    return 1
+}
+```
+
+Wire it into `cmd_listen` between the STT call and the `echo "$text"` at
+line 260:
+
+```bash
+    if is_stop_phrase "$text"; then
+        echo "[talk] Stop phrase detected: ending session" >&2
+        rm -f "$file"
+        echo ""           # empty stdout = session ended
+        exit 0
+    fi
+    echo "$text"
+    rm -f "$file"
+```
+
+### Verification
+
+- `bash -n talk.sh` — syntax check, must pass.
+- Unit-style test for `is_stop_phrase` (inline bash):
+  ```bash
+  TALK_STOP_PHRASES="stop talk|para de hablar" bash -c '
+      source /Users/op/.config/opencode/skills/talk/talk.sh 2>/dev/null
+      is_stop_phrase "ok Stop Talk everyone"   && echo PASS || echo FAIL
+      is_stop_phrase "para de hablar ya"       && echo PASS || echo FAIL
+      is_stop_phrase "i would like to talk"    && echo FAIL || echo PASS
+  '
+  ```
+  *(note: `source` will execute the orchestrator's `case` dispatch since
+  talk.sh has no `main`-style guard; a proper test calls the function
+  via a sub-shell with the case blocked, or via a test harness that
+  sources just the function. See test plan below.)*
+- Live smoke: `TALK_STOP_PHRASES="stop talk" talk.sh listen` then say
+  "stop talk" — expect empty stdout + "Stop phrase detected" on stderr.
+- Live smoke: 5-min silence in `cmd_listen` — expect empty stdout.
+- Live smoke: `Ctrl+C` during `cmd_listen` — expect script exit, no
+  zombie processes.
+
+## Section 3 — Error Handling
+
+| Failure                    | Behavior                                                | Change?         |
+|----------------------------|---------------------------------------------------------|-----------------|
+| STT returns empty          | `text=""` → no stop-phrase match → empty stdout → loop   | None (resilient) |
+| VAD recorder crash         | empty stdout, falls through to next `cmd_listen`        | None            |
+| Agent / LLM crash          | empty response, skip TTS, fall through to listen        | None            |
+| TTS engine failure         | `tts.sh` returns nonzero; agent sees empty stdout       | Verify in test  |
+| Stop-phrase false positive | *"I want to stop talking now"* → matches `"stop talk"`  | Document caveat |
+| Subprocess cleanup on exit | `trap cleanup EXIT INT TERM` (already present)          | Verify          |
+| macOS SIGINT to subprocess | Bash `wait` propagates; children reaped                 | Verify          |
+
+**TTS failure wrapper** (~2 lines, optional safety): if `tts.sh` returns
+nonzero, `cmd_speak` should not crash. Existing `set -e` at line 20
+already exits on any failure. Wrap the TTS call:
+
+```bash
+if ! bash "$TTS_SH" "$text" "$lang"; then
+    echo "[talk] TTS failed, ending session" >&2
+    exit 1
+fi
+```
+
+This converts TTS failure into a clean exit-with-error rather than a
+silent crash.
+
+## Section 4 — SKILL.md Updates
+
+| Section | Change |
+|---------|--------|
+| Header  | Note that "session persists until cancel" |
+| Talk loop (step 4) | Document 3 cancel signals: 5-min silence, spoken stop phrase, keyboard |
+| Idle timeout | Update default from 30 → 300; mention it's now the session-silence window |
+| New env var | Add `TALK_STOP_PHRASES` to the table |
+| New troubleshooting row | "Loop never ends" → set `TALK_IDLE_TIMEOUT_S` or speak stop phrase |
+| Caveat | "Stop phrase uses substring match — phrases like *'I want to stop talking'* may match. Use `TALK_STOP_PHRASES='end session'` for tighter control." |
+
+## Non-Goals
+
+- Word-boundary stop-phrase matching (future improvement).
+- A `talk.sh loop` agent-friendly mode that handles the LLM call in-shell
+  (existing `cmd_loop` does this for tty but skips the agent's tool
+  layer; out of scope).
+- Per-phrase TTS engine selection (out of scope).
+- Multi-language stop-phrase list as separate env var (single
+  pipe-separated `TALK_STOP_PHRASES` is sufficient for v1).
+
+## Rollout
+
+1. Write design doc (this file).
+2. Edit `talk.sh` (3 changes, ~12 lines added).
+3. Edit `SKILL.md` (~10 line changes).
+4. Run `bash -n talk.sh` to verify syntax.
+5. Run an inline `is_stop_phrase` smoke test.
+6. Live smoke: speak "stop talk" and confirm session ends.
+7. Commit on a feature branch; report.

--- a/service/talk.sh
+++ b/service/talk.sh
@@ -93,8 +93,16 @@ fi
 # Grace period (ms) before barge-in VAD activates after TTS playback starts
 # Prevents the VAD from triggering on the initial TTS audio burst
 : "${TALK_BARGE_IN_DELAY_MS:=2000}"
-# Idle timeout: exit listen if no speech detected within N seconds (0=disabled)
-: "${TALK_IDLE_TIMEOUT_S:=30}"
+# Idle timeout: exit listen if no speech detected within N seconds (0=disabled).
+# Session-silence window: if the user is silent for this long, cmd_listen
+# returns empty stdout, signalling the agent to end the conversation loop.
+# Default 300s (5 min) keeps the session open across natural pauses.
+: "${TALK_IDLE_TIMEOUT_S:=300}"
+# Spoken phrases that end the session (case-insensitive substring match,
+# pipe-separated). Default: "stop talk". Spanish example: "para de hablar".
+# When matched, cmd_listen prints empty stdout (= "session ended") so the
+# agent's outer `while true; do talk.sh speak; done` loop can exit.
+: "${TALK_STOP_PHRASES:=stop talk}"
 # -----------------------------------------------------------------------------
 
 # Auto-detect Python
@@ -199,6 +207,27 @@ cmd_ready_cue() {
     fi
 }
 
+# True if $1 matches any of the | separated phrases in TALK_STOP_PHRASES
+# (case-insensitive substring match). Used by cmd_listen to detect a
+# user-initiated session cancel.
+# Uses word-splitting (not read -a) for bash 3.2 portability.
+is_stop_phrase() {
+    local text
+    text=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+    local phrases_lower
+    phrases_lower=$(printf '%s' "${TALK_STOP_PHRASES:-stop talk}" | tr '[:upper:]' '[:lower:]')
+    local saved_ifs="$IFS"
+    IFS='|'
+    for phrase in $phrases_lower; do
+        [ -z "$phrase" ] && continue
+        case "$text" in
+            *"$phrase"*) IFS="$saved_ifs"; return 0 ;;
+        esac
+    done
+    IFS="$saved_ifs"
+    return 1
+}
+
 cmd_listen() {
     local outfile="${1:-opencode-utterance.wav}"
     local ready_delay=0
@@ -216,7 +245,7 @@ cmd_listen() {
         --vad-threshold "$VAD_THRESHOLD" \
         --min-silence-ms "$VAD_MIN_SILENCE_MS" \
         --ready-delay-ms "$ready_delay" \
-        --idle-timeout-s "${TALK_IDLE_TIMEOUT_S:-30}" \
+        --idle-timeout-s "${TALK_IDLE_TIMEOUT_S:-300}" \
         2>/dev/null >"$vad_out" &
     local vad_pid=$!
 
@@ -257,6 +286,13 @@ with open('$vad_out') as f:
         return 1
     fi
 
+    if is_stop_phrase "$text"; then
+        echo "[talk] Stop phrase detected (\"$text\"): ending session" >&2
+        rm -f "$file"
+        echo ""
+        exit 0
+    fi
+
     echo "$text"
     rm -f "$file"
 }
@@ -274,14 +310,17 @@ cmd_speak() {
     fi
 
     # Simple mode: TTS generates + plays, then listen
-    TTS_ENGINE="$TTS_ENGINE" \
+    if ! TTS_ENGINE="$TTS_ENGINE" \
     VIBEVOICE_MODEL="${VIBEVOICE_MODEL:-vibe-realtime-8bit}" \
     VIBEVOICE_VOICE="${VIBEVOICE_VOICE:-en-Emma_woman}" \
     VIBEVOICE_VOICE_AUTO="${VIBEVOICE_VOICE_AUTO:-1}" \
     VIBEVOICE_CFG_SCALE="${VIBEVOICE_CFG_SCALE:-2.0}" \
     VIBEVOICE_DDPM_STEPS="${VIBEVOICE_DDPM_STEPS:-15}" \
     VIBEVOICE_WS_URI="${VIBEVOICE_WS_URI:-ws://127.0.0.1:8010/ws/tts}" \
-        bash "$TTS_SH" "$text" "$lang"
+        bash "$TTS_SH" "$text" "$lang"; then
+        echo "[talk] TTS failed for text: $text" >&2
+        return 1
+    fi
 
     if [ "${TALK_AUTO_LISTEN}" = "1" ]; then
         echo "Listening for your reply…" >&2

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -64,14 +64,30 @@ When the user enters talk/voice mode:
 3. **Speak + listen** — `talk.sh speak '<reply>'` (escape single quotes). This plays TTS, then **opens the mic immediately** when audio ends. **Stdout = the user's next utterance** (same as `listen`).
 4. **Loop** — Go to step 2 with the text from step 3. **Do not call `listen` separately** after `speak` (it is built in).
 
+The session **persists** across natural pauses and stays open until the user explicitly cancels via one of three signals:
+
+| Signal | Trigger | Empty stdout → agent exits loop |
+|--------|---------|--------------------------------|
+| Keyboard | `Ctrl+C` / `Cmd+D` (sent to `talk.sh`) | n/a — process killed |
+| Session silence | No speech for `TALK_IDLE_TIMEOUT_S` (default 300s = 5 min) | yes |
+| Spoken stop phrase | User says any phrase in `TALK_STOP_PHRASES` (default `"stop talk"`) | yes |
+
+When you receive empty stdout from `talk.sh speak`, **exit the conversation loop** cleanly — the user has ended the session. Do not call `talk.sh listen` again to "recover"; respect the cancel.
+
 ### Idle timeout
 
-`listen` exits cleanly with empty stdout after `TALK_IDLE_TIMEOUT_S` seconds (default: 30) if no speech is detected.
+`listen` exits cleanly with empty stdout after `TALK_IDLE_TIMEOUT_S` seconds (default: **300** = 5 min) if no speech is detected. This is the **session-silence window**: if the user walks away, the loop ends after 5 min of silence. Set `TALK_IDLE_TIMEOUT_S=0` to disable, or override per-session with e.g. `TALK_IDLE_TIMEOUT_S=1800 talk.sh speak …` for 30 min.
+
+### Stop phrases
+
+`TALK_STOP_PHRASES` is a pipe-separated list of phrases that end the session (case-insensitive substring match). Default: `"stop talk"`. Spanish: `TALK_STOP_PHRASES="stop talk|para de hablar"`. When matched, `cmd_listen` prints `"[talk] Stop phrase detected"` to stderr and empty stdout to the agent.
+
+> **Caveat:** substring match is intentionally permissive — *"I want to stop talking now"* matches `"stop talk"`. For tighter control, use a longer phrase: `TALK_STOP_PHRASES="end the conversation"`. Word-boundary matching is a planned future improvement.
 
 ### Rules
 
 - Always invoke `talk.sh` via Shell; never fake transcription or audio.
-- Empty stdout from `speak` (no speech detected) → `talk.sh listen` once, then continue.
+- **Empty stdout from `speak`** = user ended the session (stop phrase, silence timeout, or keyboard). Exit the conversation loop; do not retry `listen`.
 - One-off read-aloud only (no mic): `TALK_AUTO_LISTEN=0 talk.sh speak '…'`.
 - TTS down (all engines failed) → fix backends; do not use macOS `say`.
 - First session turn: `talk.sh status` if services were recently restarted.
@@ -96,7 +112,8 @@ When the user enters talk/voice mode:
 | `MIC_QUERY` | MacBook Air Microphone | Substring to select the mic |
 | `TALK_AUTO_LISTEN` | `1` | After `speak`, run `listen` |
 | `TALK_BARGE_IN` | `0` | Interrupt TTS on speech (opt-in) |
-| `TALK_IDLE_TIMEOUT_S` | `30` | Exit listen if no speech (0=disabled) |
+| `TALK_IDLE_TIMEOUT_S` | `300` | Session-silence window: exit listen if no speech within N seconds (0=disabled, 300=5 min) |
+| `TALK_STOP_PHRASES` | `stop talk` | Pipe-separated phrases that end the session (case-insensitive substring match) |
 
 ## Troubleshooting
 
@@ -109,6 +126,8 @@ When the user enters talk/voice mode:
 | No audio on Linux | Install ffmpeg: `sudo apt install ffmpeg` or `sudo dnf install ffmpeg` |
 | No audio on Windows | Install ffmpeg: `winget install Gyan.FFmpeg` |
 | xAI TTS fails | Check `XAI_API_KEY` is set; `talk.sh status` shows key status |
-| Listen blocks forever | Set `TALK_IDLE_TIMEOUT_S` (default 30s) |
+| Listen blocks forever | Set `TALK_IDLE_TIMEOUT_S` (default 300s = 5 min); check that mic is working with `talk.sh devices` |
+| Want to end the conversation | Speak any phrase in `TALK_STOP_PHRASES` (default `"stop talk"`), wait 5 min in silence, or send `Ctrl+C` to `talk.sh` |
+| Agent keeps re-calling `listen` after cancel | Empty stdout from `talk.sh speak` means session ended — break out of the loop, do not retry `listen` |
 | All TTS failed | Fix backends; system TTS fallback intentionally not used |
 | Backends not running | Rerun `./setup.sh` (macOS/Linux) or `.\setup.ps1` (Windows) |


### PR DESCRIPTION
## What changed

**talk.sh (+45 lines):**
- `TALK_IDLE_TIMEOUT_S` bumped from 30s → 300s (5 min session-silence window)
- New `TALK_STOP_PHRASES` env var (pipe-separated, default `"stop talk"`)
- `is_stop_phrase()` helper with bash 3.2 portability (word-splitting, not `read -a`)
- Stop-phrase check wired into `cmd_listen` after STT transcription
- TTS failure wrapped in `if ! ...` for clean exit instead of crash

**SKILL.md (+28 lines):**
- Documented three cancel signals: keyboard, 5-min silence, spoken stop phrase
- `TALK_STOP_PHRASES` added to env var table
- Troubleshooting rows for loop-permanence and cancel signals
- Caveat documented: substring match is permissive

**Design doc:** `docs/superpowers/specs/2026-06-13-talk-session-persistence.md`

## How verified

- [x] `bash -n` syntax check passes
- [x] 12 unit tests for `is_stop_phrase()` — all pass (case-insensitive, multi-phrase, false positives, IFS restore, pipe-in-text)
- [x] `talk.sh devices` smoke test runs cleanly
- [x] Diff between repo canonical and deployed copies confirms session-persistence changes are identical
- [ ] Live voice test (requires human to speak "stop talk")

## Rollback

```bash
git revert 32810a1
```

Set `TALK_IDLE_TIMEOUT_S=30` to restore the pre-change behavior; unset `TALK_STOP_PHRASES` to disable stop-phrase detection.