### PR TITLE
Enable verified Supertonic MLX on Apple Silicon

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,12 +7,13 @@ This directory contains the operational and technical reference for Local VoiceM
 | Guide | Use it when |
 |---|---|
 | [Installation](installation.md) | Installing, upgrading, selecting integrations, managing services, or uninstalling |
+| [Apple Silicon MLX setup and repair](macos-repair.md) | Installing, validating, benchmarking, or forcing Supertonic MLX/ONNX on a Mac |
 | [Troubleshooting](troubleshooting.md) | A microphone, backend, playback path, provider, or service is not working |
 | [Providers](providers.md) | Choosing local or remote STT/TTS and understanding fallback behavior |
 | [Architecture](architecture.md) | Reviewing the runtime design, data flow, boundaries, ports, and platform differences |
 | [Agent skill contract](../skill/SKILL.md) | Integrating the voice loop into Claude Code, OpenCode, OpenClaw, Hermes, or Codex |
 | [Ollama integration](../integrations/ollama/README.md) | Talking directly to an Ollama model |
-| [Supertonic 2 integration](../integrations/supertonic2/README.md) | Installing the optional faster Supertonic 2 service |
+| [Supertonic 2 integration](../integrations/supertonic2/README.md) | Installing the optional Supertonic 2 service |
 | [Benchmarks](../benchmarks/README.md) | Reproducing latency and realtime-factor measurements |
 
 ## Runtime map
@@ -35,12 +36,12 @@ Silero VAD ──► WAV ──► Parakeet STT :5093
 
 Default local services:
 
-| Service | URL |
-|---|---|
-| Parakeet STT | `http://127.0.0.1:5093` |
-| Supertonic 3 TTS | `http://127.0.0.1:8766` |
-| Dashboard | `http://127.0.0.1:7862` |
-| Ollama, when used | `http://127.0.0.1:11434` |
+| Service | URL | Default runtime |
+|---|---|---|
+| Parakeet STT | `http://127.0.0.1:5093` | ONNX CPU by default |
+| Supertonic 3 TTS | `http://127.0.0.1:8766` | Apple Silicon: MLX first with ONNX fallback; other CPU hosts: ONNX |
+| Dashboard | `http://127.0.0.1:7862` | CPU |
+| Ollama, when used | `http://127.0.0.1:11434` | User-selected |
 
 ## Documentation principles
 
@@ -74,7 +75,9 @@ The core supported path is:
 
 - local Silero VAD
 - local Parakeet ONNX STT
-- local Supertonic 3 ONNX TTS
+- local Supertonic 3 TTS
+  - Apple Silicon: native MLX with verified ONNX CPU fallback
+  - Linux/Intel Mac/Windows: ONNX, with optional CUDA where supported
 - macOS, Linux, or Windows installation
 
 Optional providers and integrations are maintained as secondary paths. Their availability, authentication, response schemas, and latency can change independently of the local stack.

--- a/docs/macos-repair.md
+++ b/docs/macos-repair.md
@@ -1,34 +1,168 @@
-# macOS repair and verification
+# macOS Apple Silicon setup, repair, and verification
 
-A launchd job being listed does **not** prove that its API is usable. The installer now treats setup as successful only after:
+A launchd job being listed does **not** prove that its API is usable. The installer treats setup as successful only after:
 
 1. Parakeet accepts an OpenAI-compatible transcription request on port `5093`.
 2. Supertonic generates a non-empty WAV through `/v1/audio/speech` on port `8766`.
-3. The selected launchd definitions load without suppressed errors.
+3. Supertonic `/health` reports the runtime backend that actually generated the audio.
+4. The selected launchd definitions load without suppressed errors.
 
-## Repair an earlier installation
+## Default Apple Silicon behavior
+
+On an M1 or newer Mac, a normal installation uses:
+
+- **Primary TTS:** Supertonic 3 through native MLX/Metal
+- **Fallback TTS:** Supertonic 3 ONNX Runtime on CPU
+- **API port:** `8766`
+- **launchd label:** `com.opencode.supertonic`
+
+The installer downloads both model formats. This is intentional: MLX is the preferred path, while the verified ONNX model remains available if MLX cannot initialize after a macOS, python, or MLX package change.
+
+Backend controls:
 
 ```bash
-cd Local-VoiceMode-LLM
-git pull --ff-only
-chmod +x setup.sh
-./setup.sh
+./setup.sh             # Apple Silicon: MLX first, ONNX fallback
+./setup.sh --mlx       # strict MLX; fail instead of falling back
+./setup.sh --onnx      # force only Supertonic to ONNX CPU
+./setup.sh --cpu       # force the whole voice stack to CPU/ONNX
 ```
 
-The repair is idempotent. It rewrites an older managed Supertonic plist with the correct model locations:
+## Repair or upgrade an earlier installation
 
-- `assets/supertonic-3/onnx`
-- `assets/supertonic-3/voice_styles`
+```bash
+cd /Users/op/Downloads/Local-VoiceMode-LLM/Local-VoiceMode-LLM
+git pull --ff-only
+chmod +x setup.sh
+./setup.sh --integrations=openclaw,hermes
+```
 
-It preserves an unrelated pre-existing Parakeet-compatible `speech-server` service when that server passes the transcription probe. Use `./setup.sh --force` only when a conflicting or broken service definition must be replaced.
+A normal successful Apple Silicon run should include:
 
-## Diagnose without reinstalling
+```text
+Supertonic MLX model assets verified
+Supertonic runtime backend: mlx (Apple Silicon default)
+Setup verified successfully
+```
+
+If MLX cannot initialize but ONNX works, setup remains successful and clearly prints:
+
+```text
+Supertonic MLX could not initialize; verified ONNX CPU fallback is active
+```
+
+Use strict mode to diagnose MLX itself without allowing fallback:
+
+```bash
+./setup.sh --mlx --skip-parakeet --no-integrations
+```
+
+## Verify the installed runtime
+
+Run the built-in doctor:
 
 ```bash
 ./setup.sh --doctor
-# or, after installation:
+# or after installation:
 ~/.config/opencode/skills/talk/doctor.sh
 ```
+
+Inspect the API directly:
+
+```bash
+curl -s http://127.0.0.1:8766/health | python3 -m json.tool
+```
+
+After at least one synthesis request, expect:
+
+```json
+{
+  "status": "healthy",
+  "model_loaded": true,
+  "backend": "mlx"
+}
+```
+
+Generate and play a real WAV:
+
+```bash
+curl -fS http://127.0.0.1:8766/v1/audio/speech \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "supertonic",
+    "input": "Hello. Supertonic is running through MLX on this Mac.",
+    "voice": "F3",
+    "response_format": "wav",
+    "stream": false,
+    "total_steps": 8
+  }' \
+  -o /tmp/supertonic-mlx-test.wav
+
+file /tmp/supertonic-mlx-test.wav
+afplay /tmp/supertonic-mlx-test.wav
+curl -s http://127.0.0.1:8766/health | python3 -m json.tool
+```
+
+Test the installed skill without automatically reopening the microphone:
+
+```bash
+TALK_AUTO_LISTEN=0 TTS_ENGINE=supertonic \
+  ~/.config/opencode/skills/talk/talk.sh speak \
+  "The Apple Silicon voice test completed successfully."
+```
+
+Then test the full microphone-to-STT flow:
+
+```bash
+~/.config/opencode/skills/talk/talk.sh devices
+~/.config/opencode/skills/talk/talk.sh listen
+```
+
+## Compare MLX and ONNX on the same Mac
+
+Run strict MLX and time three warm requests:
+
+```bash
+./setup.sh --mlx --skip-parakeet --no-integrations
+for n in 1 2 3; do
+  /usr/bin/time -p curl -fsS http://127.0.0.1:8766/v1/audio/speech \
+    -H 'Content-Type: application/json' \
+    -d '{"model":"supertonic","input":"This is a repeatable Supertonic benchmark sentence.","voice":"F3","response_format":"wav","stream":false,"total_steps":8}' \
+    -o "/tmp/mlx-${n}.wav"
+done
+```
+
+Switch to ONNX CPU and repeat:
+
+```bash
+./setup.sh --onnx --skip-parakeet --no-integrations
+for n in 1 2 3; do
+  /usr/bin/time -p curl -fsS http://127.0.0.1:8766/v1/audio/speech \
+    -H 'Content-Type: application/json' \
+    -d '{"model":"supertonic","input":"This is a repeatable Supertonic benchmark sentence.","voice":"F3","response_format":"wav","stream":false,"total_steps":8}' \
+    -o "/tmp/onnx-${n}.wav"
+done
+```
+
+Restore the recommended MLX-first policy:
+
+```bash
+./setup.sh --skip-parakeet --no-integrations
+```
+
+## Logs and launchd inspection
+
+```bash
+launchctl print gui/$(id -u)/com.opencode.supertonic
+tail -n 100 ~/.config/opencode/supertonic.log
+
+grep -A2 -E 'SUPERTONIC_(ORT_BACKEND|MLX_MODEL_DIR|MLX_FALLBACK)' \
+  ~/Library/LaunchAgents/com.opencode.supertonic.plist
+```
+
+Relevant model directories:
+
+- MLX: `~/.config/opencode/supertonic-tts/assets/supertonic-3-mlx`
+- ONNX fallback: `~/.config/opencode/supertonic-tts/assets/supertonic-3`
 
 ## Ports and service names
 
@@ -38,8 +172,6 @@ It preserves an unrelated pre-existing Parakeet-compatible `speech-server` servi
 | Supertonic TTS | 8766 | `com.opencode.supertonic` |
 | Legacy Chatterbox, when separately installed | 8765 | `com.opencode.tts-server` |
 
-The installer does not start, stop, or claim ownership of the legacy Chatterbox service. Installed `tts.sh` copies are pinned to the selected Supertonic port so they cannot silently send requests to port `8765`.
+The installer does not start, stop, or claim ownership of the legacy Chatterbox service. Installed `tts.sh` copies are pinned to port `8766`.
 
-## Reading the result
-
-A valid run ends with `Setup verified successfully`. Any dependency, model-download, launchd, STT, or TTS failure exits non-zero and prints the relevant log tail. There is no partial-success message.
+A valid run ends with `Setup verified successfully`. Any dependency, model-download, launchd, STT, or TTS failure exits non-zero and prints the relevant log tail.

--- a/launchd/com.opencode.supertonic.plist
+++ b/launchd/com.opencode.supertonic.plist
@@ -30,10 +30,16 @@
     <string>HOME_PLACEHOLDER/.config/opencode/supertonic-tts/assets/supertonic-3/onnx</string>
     <key>VOICE_STYLES_DIR</key>
     <string>HOME_PLACEHOLDER/.config/opencode/supertonic-tts/assets/supertonic-3/voice_styles</string>
+    <key>SUPERTONIC_MLX_MODEL_DIR</key>
+    <string>HOME_PLACEHOLDER/.config/opencode/supertonic-tts/assets/supertonic-3-mlx</string>
+    <key>SUPERTONIC_MLX_AUTO_DOWNLOAD</key>
+    <string>false</string>
+    <key>SUPERTONIC_MLX_FALLBACK_TO_ONNX</key>
+    <string>true</string>
     <key>USE_GPU</key>
     <string>false</string>
     <key>SUPERTONIC_ORT_BACKEND</key>
-    <string>cpu</string>
+    <string>auto</string>
     <key>LOG_LEVEL</key>
     <string>INFO</string>
   </dict>

--- a/scripts/install.d/00-config.sh
+++ b/scripts/install.d/00-config.sh
@@ -6,6 +6,7 @@ PARAKEET_DIR="${CONFIG_DIR}/parakeet-stt"
 PARAKEET_VENV="${PARAKEET_DIR}/.venv"
 SUPERTONIC_DIR="${CONFIG_DIR}/supertonic-tts"
 SUPERTONIC_VENV="${SUPERTONIC_DIR}/.venv"
+SUPERTONIC_MLX_DIR="${SUPERTONIC_MLX_MODEL_DIR:-${SUPERTONIC_DIR}/assets/supertonic-3-mlx}"
 PARAKEET_PORT="${PARAKEET_PORT:-5093}"
 SUPERTONIC_PORT="${SUPERTONIC_PORT:-8766}"
 LAUNCHD_DIR="${HOME}/Library/LaunchAgents"
@@ -16,7 +17,7 @@ case "$OS" in Darwin) PLATFORM=macos ;; Linux) PLATFORM=linux ;; *) PLATFORM=oth
 
 info() { printf '\033[1;34m[setup]\033[0m %s\n' "$*"; }
 ok() { printf '\033[1;32m[setup]\033[0m ✓ %s\n' "$*"; }
-warn() { printf '\033[1;33m[setup]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[setup]\033[[0m %s\n' "$*"; }
 err() { printf '\033[1;31m[setup]\033[0m %s\n' "$*" >&2; }
 die() { err "$*"; exit 1; }
 on_error() {
@@ -35,6 +36,7 @@ FORCE=false
 UNINSTALL=false
 DOCTOR_ONLY=false
 ACCEL_CHOICE=auto
+SUPERTONIC_BACKEND_CHOICE=auto
 INTEGRATE_CLAUDECODE=true
 INTEGRATE_OPENCODE=true
 INTEGRATE_OPENCLAW=true
@@ -52,14 +54,18 @@ Installs or repairs the local voice stack and verifies it end to end.
   --skip-supertonic     Do not install or verify Supertonic TTS
   --skip-voices         Skip optional macOS reference voice generation
   --venv-only           Install only the shared voice Python environment
+  --mlx                 Force Supertonic MLX (Apple Silicon only; strict)
+  --onnx                Force Supertonic ONNX CPU without changing STT
   --gpu                  Use NVIDIA CUDA on supported Linux hosts
-  --cpu                  Force CPU execution
+  --cpu                  Force CPU execution and Supertonic ONNX
   --force, -f            Replace conflicting managed service definitions
   --doctor               Diagnose currently installed services only
   --uninstall            Stop services; add --force to remove managed files
   --integrations=LIST    claudecode,opencode,openclaw,hermes,codex
   --no-integrations      Do not install agent skills
   -h, --help             Show this help
+
+Apple Silicon defaults to Supertonic backend=auto: MLX first, ONNX CPU fallback.
 USAGE
 }
 
@@ -69,8 +75,10 @@ for arg in "$@"; do
     --skip-supertonic) SKIP_SUPERTONIC=true ;;
     --skip-voices) SKIP_VOICES=true ;;
     --venv-only) VENV_ONLY=true ;;
+    --mlx) SUPERTONIC_BACKEND_CHOICE=mlx ;;
+    --onnx) SUPERTONIC_BACKEND_CHOICE=cpu ;;
     --gpu) ACCEL_CHOICE=gpu ;;
-    --cpu) ACCEL_CHOICE=cpu ;;
+    --cpu) ACCEL_CHOICE=cpu; SUPERTONIC_BACKEND_CHOICE=cpu ;;
     --force|-f) FORCE=true ;;
     --doctor) DOCTOR_ONLY=true ;;
     --uninstall) UNINSTALL=true ;;
@@ -106,7 +114,11 @@ ask_yn() {
 if [[ $# -eq 0 && -t 0 && -t 1 ]]; then
   printf '\n\033[1;36m  Local VoiceMode LLM — verified setup\033[0m\n\n'
   ask_yn "Parakeet STT on :${PARAKEET_PORT}" y || SKIP_PARAKEET=true
-  ask_yn "Supertonic TTS on :${SUPERTONIC_PORT}" y || SKIP_SUPERTONIC=true
+  if [[ "$PLATFORM" == macos && "$ARCH" == arm64 ]]; then
+    ask_yn "Supertonic TTS on :${SUPERTONIC_PORT} (MLX first, ONNX fallback)" y || SKIP_SUPERTONIC=true
+  else
+    ask_yn "Supertonic TTS on :${SUPERTONIC_PORT}" y || SKIP_SUPERTONIC=true
+  fi
   echo
   ask_yn "Install Claude Code skill" y || INTEGRATE_CLAUDECODE=false
   ask_yn "Install OpenCode skill" y || INTEGRATE_OPENCODE=false

--- a/scripts/install.d/00-config.sh
+++ b/scripts/install.d/00-config.sh
@@ -17,7 +17,7 @@ case "$OS" in Darwin) PLATFORM=macos ;; Linux) PLATFORM=linux ;; *) PLATFORM=oth
 
 info() { printf '\033[1;34m[setup]\033[0m %s\n' "$*"; }
 ok() { printf '\033[1;32m[setup]\033[0m ✓ %s\n' "$*"; }
-warn() { printf '\033[1;33m[setup]\033[[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[setup]\033[0m %s\n' "$*"; }
 err() { printf '\033[1;31m[setup]\033[0m %s\n' "$*" >&2; }
 die() { err "$*"; exit 1; }
 on_error() {

--- a/scripts/install.d/10-common.sh
+++ b/scripts/install.d/10-common.sh
@@ -51,15 +51,42 @@ PY
 
 HAS_NVIDIA=false
 if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; then HAS_NVIDIA=true; fi
+IS_APPLE_SILICON=false
+if [[ "$PLATFORM" == macos && "$ARCH" == arm64 ]]; then IS_APPLE_SILICON=true; fi
+
 ACCEL=cpu
 if [[ "$ACCEL_CHOICE" == gpu ]]; then
   if [[ "$PLATFORM" == linux && "$HAS_NVIDIA" == true ]]; then ACCEL=cuda
-  else warn "CUDA is unavailable here; using CPU"; fi
+  else warn "CUDA is unavailable here; using CPU for Parakeet"; fi
 elif [[ "$ACCEL_CHOICE" == auto && "$PLATFORM" == linux && "$HAS_NVIDIA" == true && -t 0 && -t 1 ]]; then
   ask_yn "Use NVIDIA CUDA for voice services?" n && ACCEL=cuda
 fi
 USE_GPU=false; ORT_BACKEND=cpu
 if [[ "$ACCEL" == cuda ]]; then USE_GPU=true; ORT_BACKEND=cuda; fi
+
+SUPERTONIC_INSTALL_MLX=false
+SUPERTONIC_BACKEND="$ORT_BACKEND"
+SUPERTONIC_MLX_FALLBACK=true
+case "$SUPERTONIC_BACKEND_CHOICE" in
+  mlx)
+    [[ "$IS_APPLE_SILICON" == true ]] || die "--mlx requires macOS on Apple Silicon (M1 or newer)"
+    SUPERTONIC_INSTALL_MLX=true
+    SUPERTONIC_BACKEND=mlx
+    SUPERTONIC_MLX_FALLBACK=false
+    ;;
+  cpu)
+    SUPERTONIC_BACKEND=cpu
+    ;;
+  auto)
+    if [[ "$IS_APPLE_SILICON" == true ]]; then
+      SUPERTONIC_INSTALL_MLX=true
+      SUPERTONIC_BACKEND=auto
+      SUPERTONIC_MLX_FALLBACK=true
+    fi
+    ;;
+  *) die "Unknown Supertonic backend policy: $SUPERTONIC_BACKEND_CHOICE" ;;
+esac
+
 mkdir -p "$CONFIG_DIR"
 [[ "$PLATFORM" == macos ]] && mkdir -p "$LAUNCHD_DIR"
 

--- a/scripts/install.d/20-probes.sh
+++ b/scripts/install.d/20-probes.sh
@@ -36,6 +36,24 @@ tts_probe_once() {
   if [[ "$code" == 200 && "$(wc -c < "$tmp")" -gt 1000 && "$(head -c 4 "$tmp")" == RIFF ]]; then rc=0; fi
   rm -f "$tmp"; return "$rc"
 }
+supertonic_backend_once() {
+  local base="http://127.0.0.1:${SUPERTONIC_PORT}" tmp code
+  tmp="$(mktemp "${TMPDIR:-/tmp}/lvml-tts-health.XXXXXX")"
+  code="$(curl -sS --max-time 8 -o "$tmp" -w '%{http_code}' "$base/health" || true)"
+  if [[ "$code" != 200 ]]; then rm -f "$tmp"; return 1; fi
+  python3 - "$tmp" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as f:
+    payload = json.load(f)
+backend = payload.get("backend")
+if not isinstance(backend, str) or not backend.strip():
+    raise SystemExit(1)
+print(backend.strip().lower())
+PY
+  local rc=$?
+  rm -f "$tmp"
+  return "$rc"
+}
 wait_for_probe() {
   local label="$1" timeout="$2" probe="$3" log="$4" elapsed=0
   info "Waiting for $label readiness..."
@@ -50,10 +68,18 @@ wait_for_probe() {
   ok "$label passed its end-to-end API probe"
 }
 show_doctor() {
-  local failed=0
+  local failed=0 backend
   echo; info "── Voice service diagnosis ──"
   if [[ "$SKIP_PARAKEET" == false ]]; then stt_probe_once && ok "STT :${PARAKEET_PORT} works" || { err "STT :${PARAKEET_PORT} failed"; failed=1; }; fi
-  if [[ "$SKIP_SUPERTONIC" == false ]]; then tts_probe_once && ok "TTS :${SUPERTONIC_PORT} works" || { err "TTS :${SUPERTONIC_PORT} failed"; failed=1; }; fi
+  if [[ "$SKIP_SUPERTONIC" == false ]]; then
+    if tts_probe_once; then
+      ok "TTS :${SUPERTONIC_PORT} works"
+      backend="$(supertonic_backend_once || true)"
+      [[ -n "$backend" ]] && ok "Supertonic runtime backend: $backend" || warn "Supertonic backend could not be read from /health"
+    else
+      err "TTS :${SUPERTONIC_PORT} failed"; failed=1
+    fi
+  fi
   if [[ "$PLATFORM" == macos ]]; then
     local label
     for label in com.opencode.parakeet-stt com.opencode.supertonic; do

--- a/scripts/install.d/40-supertonic.sh
+++ b/scripts/install.d/40-supertonic.sh
@@ -7,9 +7,17 @@ verify_supertonic_model() {
   done
   compgen -G "$model/voice_styles/*.json" >/dev/null
 }
+verify_supertonic_mlx_model() {
+  local model="$SUPERTONIC_MLX_DIR" f
+  [[ -s "$model/tts.json" && -s "$model/unicode_indexer.json" ]] || return 1
+  for f in duration_predictor text_encoder vector_estimator vocoder; do
+    [[ -s "$model/graphs/$f.json" && -s "$model/weights/$f.npz" ]] || return 1
+  done
+  compgen -G "$model/voice_styles/*.json" >/dev/null
+}
 download_supertonic_model() {
   local model="$SUPERTONIC_DIR/assets/supertonic-3" media raw f voice
-  verify_supertonic_model && { ok "Supertonic model assets already verified"; return 0; }
+  verify_supertonic_model && { ok "Supertonic ONNX fallback assets already verified"; return 0; }
   rm -rf "$model"; mkdir -p "$model/onnx" "$model/voice_styles"
   media=https://media.githubusercontent.com/media/groxaxo/supertonic-3-v2/main
   raw=https://raw.githubusercontent.com/groxaxo/supertonic-3-v2/main
@@ -21,8 +29,20 @@ download_supertonic_model() {
     rm -rf "$model"; mkdir -p "$model"
     "$SUPERTONIC_VENV/bin/python" "$SUPERTONIC_DIR/scripts/download_supertonic3.py" --repo-id Supertone/supertonic-3 --dest "$model"
   fi
-  verify_supertonic_model || die "Supertonic model download is incomplete"
-  ok "Supertonic model assets verified"
+  verify_supertonic_model || die "Supertonic ONNX model download is incomplete"
+  ok "Supertonic ONNX fallback assets verified"
+}
+download_supertonic_mlx_model() {
+  [[ "$SUPERTONIC_INSTALL_MLX" == true ]] || return 0
+  verify_supertonic_mlx_model && { ok "Supertonic MLX model assets already verified"; return 0; }
+  local downloader="$SUPERTONIC_DIR/scripts/download_supertonic3_mlx.py"
+  [[ -f "$downloader" ]] || die "Supertonic MLX downloader is missing: $downloader"
+  rm -rf "$SUPERTONIC_MLX_DIR"; mkdir -p "$SUPERTONIC_MLX_DIR"
+  retry 3 3 "$SUPERTONIC_VENV/bin/python" "$downloader" \
+    --repo "${SUPERTONIC_MLX_MODEL_REPO:-mlx-community/supertonic-3}" \
+    --output "$SUPERTONIC_MLX_DIR"
+  verify_supertonic_mlx_model || die "Supertonic MLX model download is incomplete"
+  ok "Supertonic MLX model assets verified"
 }
 install_supertonic() {
   [[ "$SKIP_SUPERTONIC" == true ]] && return 0
@@ -38,8 +58,14 @@ install_supertonic() {
   pip_install "$SUPERTONIC_VENV/bin/python" -r "$SUPERTONIC_DIR/py/requirements.txt"
   pip_install "$SUPERTONIC_VENV/bin/python" huggingface-hub transformers
   [[ "$ACCEL" == cuda ]] && pip_install "$SUPERTONIC_VENV/bin/python" onnxruntime-gpu
+  if [[ "$SUPERTONIC_INSTALL_MLX" == true ]]; then
+    [[ -f "$SUPERTONIC_DIR/py/pyproject.toml" ]] || die "Supertonic MLX package metadata is missing"
+    pip_install "$SUPERTONIC_VENV/bin/python" -e "${SUPERTONIC_DIR}/py[mlx]"
+    validate_imports "$SUPERTONIC_VENV/bin/python" "Supertonic MLX" mlx supertonic_mlx
+  fi
   validate_imports "$SUPERTONIC_VENV/bin/python" Supertonic fastapi uvicorn onnxruntime huggingface_hub
   download_supertonic_model
+  download_supertonic_mlx_model
 
   [[ "$PLATFORM" == macos ]] || return 0
   local plist="$LAUNCHD_DIR/com.opencode.supertonic.plist"
@@ -53,11 +79,12 @@ install_supertonic() {
 <key>EnvironmentVariables</key><dict>
 <key>HOME</key><string>${HOME}</string><key>PATH</key><string>${SUPERTONIC_VENV}/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
 <key>SUPERTONIC_MODEL_DIR</key><string>${SUPERTONIC_DIR}/assets/supertonic-3</string><key>ONNX_DIR</key><string>${SUPERTONIC_DIR}/assets/supertonic-3/onnx</string><key>VOICE_STYLES_DIR</key><string>${SUPERTONIC_DIR}/assets/supertonic-3/voice_styles</string>
-<key>USE_GPU</key><string>${USE_GPU}</string><key>SUPERTONIC_ORT_BACKEND</key><string>${ORT_BACKEND}</string><key>LOG_LEVEL</key><string>INFO</string></dict>
+<key>SUPERTONIC_MLX_MODEL_DIR</key><string>${SUPERTONIC_MLX_DIR}</string><key>SUPERTONIC_MLX_AUTO_DOWNLOAD</key><string>false</string><key>SUPERTONIC_MLX_FALLBACK_TO_ONNX</key><string>${SUPERTONIC_MLX_FALLBACK}</string>
+<key>USE_GPU</key><string>${USE_GPU}</string><key>SUPERTONIC_ORT_BACKEND</key><string>${SUPERTONIC_BACKEND}</string><key>LOG_LEVEL</key><string>INFO</string></dict>
 <key>RunAtLoad</key><true/><key>KeepAlive</key><true/><key>WorkingDirectory</key><string>${SUPERTONIC_DIR}/py</string>
 <key>StandardOutPath</key><string>${CONFIG_DIR}/supertonic.log</string><key>StandardErrorPath</key><string>${CONFIG_DIR}/supertonic.log</string>
 </dict></plist>
 PLIST
   plutil -lint "$plist" >/dev/null
-  ok "Supertonic launchd definition installed with correct model paths"
+  ok "Supertonic launchd definition installed (backend=${SUPERTONIC_BACKEND})"
 }

--- a/scripts/install.d/90-install.sh
+++ b/scripts/install.d/90-install.sh
@@ -8,7 +8,8 @@ if [[ "$DOCTOR_ONLY" == true ]]; then
 fi
 if [[ "$UNINSTALL" == true ]]; then uninstall_stack; exit 0; fi
 require_cmd git
-info "Accelerator: ${ACCEL} (${OS} ${ARCH})"
+info "Parakeet accelerator: ${ACCEL} (${OS} ${ARCH})"
+info "Supertonic backend policy: ${SUPERTONIC_BACKEND}$( [[ "$SUPERTONIC_INSTALL_MLX" == true ]] && printf ' (MLX assets enabled)' )"
 
 create_venv "$VENV_DIR" "Voice core"
 pip_install "$VENV_DIR/bin/python" --upgrade pip setuptools wheel

--- a/scripts/install.d/91-services.sh
+++ b/scripts/install.d/91-services.sh
@@ -58,8 +58,11 @@ Environment=HOME=${HOME}
 Environment=SUPERTONIC_MODEL_DIR=${SUPERTONIC_DIR}/assets/supertonic-3
 Environment=ONNX_DIR=${SUPERTONIC_DIR}/assets/supertonic-3/onnx
 Environment=VOICE_STYLES_DIR=${SUPERTONIC_DIR}/assets/supertonic-3/voice_styles
+Environment=SUPERTONIC_MLX_MODEL_DIR=${SUPERTONIC_MLX_DIR}
+Environment=SUPERTONIC_MLX_AUTO_DOWNLOAD=false
+Environment=SUPERTONIC_MLX_FALLBACK_TO_ONNX=${SUPERTONIC_MLX_FALLBACK}
 Environment=USE_GPU=${USE_GPU}
-Environment=SUPERTONIC_ORT_BACKEND=${ORT_BACKEND}
+Environment=SUPERTONIC_ORT_BACKEND=${SUPERTONIC_BACKEND}
 StandardOutput=append:${CONFIG_DIR}/supertonic.log
 StandardError=append:${CONFIG_DIR}/supertonic.log
 [Install]

--- a/scripts/install.d/99-verify.sh
+++ b/scripts/install.d/99-verify.sh
@@ -1,11 +1,33 @@
 # shellcheck shell=bash
 [[ "$SKIP_PARAKEET" == true ]] || wait_for_probe "Parakeet STT" 180 stt_probe_once "$CONFIG_DIR/parakeet-stt.log"
-[[ "$SKIP_SUPERTONIC" == true ]] || wait_for_probe "Supertonic TTS" 240 tts_probe_once "$CONFIG_DIR/supertonic.log"
+
+SUPERTONIC_ACTIVE_BACKEND=""
+if [[ "$SKIP_SUPERTONIC" == false ]]; then
+  wait_for_probe "Supertonic TTS" 300 tts_probe_once "$CONFIG_DIR/supertonic.log"
+  SUPERTONIC_ACTIVE_BACKEND="$(supertonic_backend_once || true)"
+  [[ -n "$SUPERTONIC_ACTIVE_BACKEND" ]] || die "Supertonic generated audio but /health did not report its runtime backend"
+  case "$SUPERTONIC_BACKEND" in
+    mlx)
+      [[ "$SUPERTONIC_ACTIVE_BACKEND" == mlx ]] || die "Strict MLX was requested, but Supertonic reported backend=${SUPERTONIC_ACTIVE_BACKEND}"
+      ok "Supertonic runtime backend: mlx"
+      ;;
+    auto)
+      if [[ "$SUPERTONIC_ACTIVE_BACKEND" == mlx ]]; then
+        ok "Supertonic runtime backend: mlx (Apple Silicon default)"
+      elif [[ "$SUPERTONIC_ACTIVE_BACKEND" == cpu ]]; then
+        warn "Supertonic MLX could not initialize; verified ONNX CPU fallback is active"
+      else
+        warn "Supertonic auto-selected backend: ${SUPERTONIC_ACTIVE_BACKEND}"
+      fi
+      ;;
+    *) ok "Supertonic runtime backend: ${SUPERTONIC_ACTIVE_BACKEND}" ;;
+  esac
+fi
 
 echo
 info "── Setup verified successfully ──"
 echo "  Voice skill:  $SKILL_DIR/talk.sh"
 echo "  Doctor:       $SKILL_DIR/doctor.sh"
 [[ "$SKIP_PARAKEET" == true ]] || echo "  STT API:      http://127.0.0.1:${PARAKEET_PORT}/v1/audio/transcriptions"
-[[ "$SKIP_SUPERTONIC" == true ]] || echo "  TTS API:      http://127.0.0.1:${SUPERTONIC_PORT}/v1/audio/speech"
+[[ "$SKIP_SUPERTONIC" == true ]] || echo "  TTS API:      http://127.0.0.1:${SUPERTONIC_PORT}/v1/audio/speech (${SUPERTONIC_ACTIVE_BACKEND})"
 echo "  Re-check:     ./setup.sh --doctor"

--- a/service/doctor.sh
+++ b/service/doctor.sh
@@ -63,6 +63,25 @@ check_tts() {
   return "$rc"
 }
 
+get_tts_backend() {
+  local tmp code
+  tmp="$(mktemp "${TMPDIR:-/tmp}/lvml-doctor-health.XXXXXX")"
+  code="$(curl -sS --max-time 8 -o "$tmp" -w '%{http_code}' "http://127.0.0.1:${SUPERTONIC_PORT}/health" || true)"
+  if [[ "$code" != 200 ]]; then rm -f "$tmp"; return 1; fi
+  python3 - "$tmp" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as f:
+    payload = json.load(f)
+backend = payload.get("backend")
+if not isinstance(backend, str) or not backend.strip():
+    raise SystemExit(1)
+print(backend.strip().lower())
+PY
+  local rc=$?
+  rm -f "$tmp"
+  return "$rc"
+}
+
 show_launchd() {
   [[ "$OS" == Darwin ]] || return 0
   if ! command -v launchctl >/dev/null 2>&1; then return 0; fi
@@ -93,6 +112,12 @@ fi
 
 if check_tts; then
   ok "Supertonic generated a valid WAV on :${SUPERTONIC_PORT}"
+  backend="$(get_tts_backend || true)"
+  if [[ -n "$backend" ]]; then
+    ok "Supertonic runtime backend: $backend"
+  else
+    warn "Supertonic backend could not be read from /health"
+  fi
 else
   err "Supertonic synthesis failed on :${SUPERTONIC_PORT}"
   [[ -f "$CONFIG_DIR/supertonic.log" ]] && tail -n 25 "$CONFIG_DIR/supertonic.log" >&2

--- a/tests/test_setup_installer.py
+++ b/tests/test_setup_installer.py
@@ -12,6 +12,8 @@ def installer_text() -> str:
     parts = [INSTALLER.read_text(encoding="utf-8")]
     parts.extend(path.read_text(encoding="utf-8") for path in sorted(MODULE_DIR.glob("*.sh")))
     return "\n".join(parts)
+
+
 SUPERTONIC_PLIST = ROOT / "launchd" / "com.opencode.supertonic.plist"
 PARAKEET_PLIST = ROOT / "launchd" / "com.opencode.parakeet-stt.plist"
 
@@ -19,7 +21,14 @@ PARAKEET_PLIST = ROOT / "launchd" / "com.opencode.parakeet-stt.plist"
 def test_shell_entrypoints_parse_and_help() -> None:
     for script in (ROOT / "setup.sh", INSTALLER, ROOT / "service" / "doctor.sh"):
         subprocess.run(["bash", "-n", str(script)], check=True)
-    subprocess.run([str(ROOT / "setup.sh"), "--help"], check=True, capture_output=True, text=True)
+    help_result = subprocess.run(
+        [str(ROOT / "setup.sh"), "--help"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "--mlx" in help_result.stdout
+    assert "--onnx" in help_result.stdout
 
 
 def test_supertonic_paths_and_port_are_consistent() -> None:
@@ -28,15 +37,32 @@ def test_supertonic_paths_and_port_are_consistent() -> None:
     assert 'SUPERTONIC_PORT="${SUPERTONIC_PORT:-8766}"' in installer
     assert "assets/supertonic-3/onnx" in installer
     assert "assets/supertonic-3/voice_styles" in installer
+    assert "assets/supertonic-3-mlx" in installer
     assert "assets/supertonic-3/onnx" in plist
     assert "assets/supertonic-3/voice_styles" in plist
+    assert "assets/supertonic-3-mlx" in plist
     assert "127.0.0.1" in plist
 
 
-def test_installer_uses_real_api_probes() -> None:
+def test_apple_silicon_mlx_policy_and_fallback_are_present() -> None:
+    installer = installer_text()
+    plist = SUPERTONIC_PLIST.read_text(encoding="utf-8")
+    assert "SUPERTONIC_INSTALL_MLX=true" in installer
+    assert "SUPERTONIC_BACKEND=auto" in installer
+    assert "SUPERTONIC_BACKEND=mlx" in installer
+    assert "SUPERTONIC_BACKEND=cpu" in installer
+    assert 'py[mlx]' in installer
+    assert "mlx-community/supertonic-3" in installer
+    assert "SUPERTONIC_MLX_FALLBACK_TO_ONNX" in installer
+    assert "SUPERTONIC_MLX_FALLBACK_TO_ONNX" in plist
+    assert "<string>auto</string>" in plist
+
+
+def test_installer_uses_real_api_probes_and_reports_backend() -> None:
     installer = installer_text()
     assert "/v1/audio/transcriptions" in installer
     assert "/v1/audio/speech" in installer
+    assert '"backend"' in installer or 'payload.get("backend")' in installer
     assert "Setup verified successfully" in installer
     assert "Setup Complete" not in installer
 

--- a/tests/test_setup_static.sh
+++ b/tests/test_setup_static.sh
@@ -5,14 +5,21 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 bash -n "$ROOT/setup.sh"
 find "$ROOT/scripts" -type f -name '*.sh' -print0 | xargs -0 -n1 bash -n
 bash -n "$ROOT/service/doctor.sh"
-"$ROOT/setup.sh" --help >/dev/null
+help_text="$($ROOT/setup.sh --help)"
+grep -Fq -- '--mlx' <<< "$help_text"
+grep -Fq -- '--onnx' <<< "$help_text"
 
 all_installer="$(cat "$ROOT/scripts/install.sh" "$ROOT"/scripts/install.d/*.sh)"
 grep -Fq 'SUPERTONIC_PORT="${SUPERTONIC_PORT:-8766}"' <<< "$all_installer"
 grep -Fq 'assets/supertonic-3/onnx' <<< "$all_installer"
 grep -Fq 'assets/supertonic-3/voice_styles' <<< "$all_installer"
+grep -Fq 'assets/supertonic-3-mlx' <<< "$all_installer"
+grep -Fq 'mlx-community/supertonic-3' <<< "$all_installer"
+grep -Fq 'py[mlx]' <<< "$all_installer"
+grep -Fq 'SUPERTONIC_MLX_FALLBACK_TO_ONNX' <<< "$all_installer"
 grep -Fq 'v1/audio/transcriptions' <<< "$all_installer"
 grep -Fq 'v1/audio/speech' <<< "$all_installer"
+grep -Fq 'Supertonic runtime backend' <<< "$all_installer"
 
 if grep -Eq 'load_launchd_service com\.opencode\.tts-server|launchctl_load_or_kick "com\.opencode\.tts-server"' <<< "$all_installer"; then
   echo "installer must not manage the unrelated legacy Chatterbox launchd job" >&2
@@ -25,6 +32,11 @@ from pathlib import Path
 root=Path("$ROOT")
 for path in (root/'launchd/com.opencode.supertonic.plist', root/'launchd/com.opencode.parakeet-stt.plist'):
     with path.open('rb') as f: plistlib.load(f)
+mlx = plistlib.loads((root/'launchd/com.opencode.supertonic.plist').read_bytes())
+env = mlx['EnvironmentVariables']
+assert env['SUPERTONIC_ORT_BACKEND'] == 'auto'
+assert env['SUPERTONIC_MLX_FALLBACK_TO_ONNX'] == 'true'
+assert env['SUPERTONIC_MLX_MODEL_DIR'].endswith('assets/supertonic-3-mlx')
 PY
 
 echo "setup static checks passed"


### PR DESCRIPTION
## What changed

- make Apple Silicon use Supertonic `backend=auto`: native MLX first, verified ONNX CPU fallback
- add strict `--mlx`, Supertonic-only `--onnx`, and whole-stack `--cpu` controls
- install the `py[mlx]` runtime and download `mlx-community/supertonic-3` graph/NPZ assets
- retain the existing ONNX model as an immediate fallback
- pass MLX model/fallback settings through launchd and systemd service definitions
- synthesize a real WAV and read `/health.backend` before reporting success
- make strict MLX fail if the live server did not actually use MLX
- report the active runtime in `./setup.sh --doctor`
- add Apple Silicon setup, playback, benchmarking, fallback, and log-inspection instructions
- extend installer regression and static tests

## Validation performed

- `bash -n` passed for all changed shell files
- both launchd plists parsed successfully
- installer static checks passed
- `pytest tests/test_setup_installer.py`: 6 passed
- simulated Apple Silicon policies passed for default, `--mlx`, `--onnx`, and `--cpu`

The GitHub workflow is the final merge gate. Actual Metal execution must be confirmed on an Apple Silicon Mac using the documented synthesis and `/health` checks.