### PR TITLE
feat: add shared xAI and Gemini VoiceMode bridge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@
 # STT_URL=http://127.0.0.1:5093/v1/audio/transcriptions
 # STT_MODEL=parakeet-tdt-0.6b-v3
 
-# Local Supertonic 3 ONNX text-to-speech
+# Local Supertonic 3 text-to-speech
 # The managed installer runs it on :8766.
 # TTS_ENGINE=supertonic
 # SUPERTONIC_URL=http://127.0.0.1:8766
@@ -37,12 +37,40 @@
 # MIC_QUERY=Headset                   # empty/unset uses automatic selection
 
 # =============================================================================
+# Optional shared AI Sentence Tagger / AI Voice Studio bridge (Unix/macOS)
+# =============================================================================
+#
+# The companion service owns the local tagging model and xAI/Google credentials.
+# Local VoiceMode calls its /api/process/json endpoint and receives a validated WAV.
+# Install with: bash integrations/ai-sentence-tagger/install.sh
+#
+# TTS_SH=$HOME/.config/opencode/ai-tts-provider/tts-provider.sh
+# AI_TTS_URL=http://127.0.0.1:8000
+# AI_TTS_PROVIDER=google              # xai | google | gemini
+# AI_TTS_VOICE=Kore                   # xAI default: eve; Google default: Kore
+# AI_TTS_SOURCE_LANGUAGE=auto         # optional tagging-language override
+# AI_TTS_LANGUAGE=auto                # synthesis language
+# AI_TTS_COVERAGE=natural             # natural | all | all-per-sentence
+# AI_TTS_STYLE_PROMPT=                # Google Director's Notes
+# AI_TTS_MODEL=gemini-3.1-flash-tts-preview
+# AI_TTS_TAGGER_MODEL=
+# AI_TTS_TAGGER_BASE_URL=
+# AI_TTS_TIMEOUT_SECONDS=180
+# AI_TTS_MAX_AUDIO_BYTES=100000000
+# AI_TTS_TOKEN=                       # optional bearer token for protected companion
+# AI_TTS_PYTHON=python3
+# AI_TTS_CODEC=wav                    # required by the VoiceMode bridge
+# AI_TTS_SAMPLE_RATE=24000            # advanced; must be provider-supported
+#
+# TTS_SH replaces the built-in Unix dispatcher for that process. Unset TTS_SH to
+# restore TTS_ENGINE routing and the normal local-first fallback graph.
+
+# =============================================================================
 # Optional local TTS backends
 # =============================================================================
 
 # Supertonic 2 service (installed separately on :8880)
 # Install: bash integrations/supertonic2/install.sh
-# The dispatcher currently uses the normal `supertonic` engine with the alternate URL.
 # TTS_ENGINE=supertonic
 # SUPERTONIC_URL=http://127.0.0.1:8880
 
@@ -65,6 +93,11 @@
 # QWEN_TTS_URL_HQ=http://127.0.0.1:18882
 # QWEN_TTS_URL_LAZY=http://127.0.0.1:18883
 # QWEN_TTS_VOICE=vivian
+
+# Windows IndexTTS CUDA service
+# TTS_ENGINE=indextts
+# INDEXTTS_URL=http://127.0.0.1:7863
+# INDEXTTS_REF_AUDIO=C:\path\to\speaker-reference.wav
 
 # =============================================================================
 # Optional remote OpenAI-compatible speech
@@ -90,7 +123,7 @@
 # OPENAI_TTS_KEY=local-token
 
 # =============================================================================
-# Optional hosted providers
+# Optional hosted providers through the built-in Unix dispatcher
 # =============================================================================
 
 # Inworld expressive TTS
@@ -103,7 +136,7 @@
 # INWORLD_TTS_ENCODING=LINEAR16
 # INWORLD_TTS_SAMPLE_RATE=48000
 
-# xAI TTS
+# Direct xAI TTS (no local sentence-tagger bridge)
 # TTS_ENGINE=xai
 # XAI_API_KEY=replace-me
 # XAI_TTS_VOICE=eve

--- a/README.md
+++ b/README.md
@@ -5,49 +5,37 @@
 <h1 align="center">Local VoiceMode LLM</h1>
 
 <p align="center">
-  <strong>Give local AI agents a fast, private voice loop without taking VRAM away from the LLM.</strong>
+  <strong>Fast, local-first voice conversations for coding agents and local LLMs—without consuming the model's VRAM.</strong>
 </p>
 
 <p align="center">
-  <a href="https://github.com/groxaxo/Local-VoiceMode-LLM/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/groxaxo/Local-VoiceMode-LLM/actions/workflows/ci.yml/badge.svg"></a>
   <img alt="macOS" src="https://img.shields.io/badge/macOS-supported-111827">
   <img alt="Linux" src="https://img.shields.io/badge/Linux-supported-111827">
   <img alt="Windows" src="https://img.shields.io/badge/Windows-supported-111827">
   <img alt="License" src="https://img.shields.io/badge/license-MIT-2563eb">
 </p>
 
-<p align="center">
-  <a href="#quick-start">Quick start</a> ·
-  <a href="#how-it-works">Architecture</a> ·
-  <a href="#supported-agents">Agents</a> ·
-  <a href="#configuration">Configuration</a> ·
-  <a href="docs/README.md">Documentation</a>
-</p>
+Local VoiceMode LLM is a cross-platform speech layer for Claude Code, OpenCode, OpenClaw, Hermes Agent, Codex, Ollama, and other local agents. The default path keeps microphone endpointing, transcription, and synthesis on the host:
 
----
-
-Local VoiceMode LLM is a cross-platform speech layer for coding agents and local LLMs. It combines:
-
-- **Silero VAD** for microphone endpointing
-- **Parakeet TDT 0.6B v3** for local speech-to-text
-- **Supertonic 3** for local text-to-speech
-- A reusable **`talk` skill** for Claude Code, OpenCode, OpenClaw, Hermes Agent, and Codex
-- An optional **Ollama voice loop** and browser dashboard
-
-The default speech path is local and CPU-oriented. On Linux with NVIDIA hardware, the installer can optionally use CUDA; remote STT/TTS providers remain opt-in.
-
-## Why this project exists
-
-Running voice on the same GPU as a large language model wastes scarce VRAM and creates avoidable deployment coupling. This project keeps the speech stack separate:
-
-| Stage | Default backend | Port | Default compute |
+| Stage | Default backend | Port | Compute |
 |---|---|---:|---|
 | Voice activity detection | Silero VAD | — | CPU |
-| Speech-to-text | Parakeet TDT 0.6B v3, ONNX | `5093` | CPU |
-| Text-to-speech | Supertonic 3, ONNX | `8766` | CPU |
+| Speech-to-text | Parakeet TDT 0.6B v3, ONNX | `5093` | CPU by default |
+| Text-to-speech | Supertonic 3, ONNX/MLX | `8766` | CPU or Apple Silicon |
 | Dashboard | FastAPI + static HTML | `7862` | CPU |
 
-That leaves the accelerator available for Ollama, vLLM, MLX, or another model server.
+The accelerator remains available for Ollama, vLLM, SGLang, MLX, or another model server.
+
+## Highlights
+
+- Real VAD-driven microphone turns—no simulated transcript or fake playback.
+- Local Parakeet transcription through an OpenAI-compatible endpoint.
+- Local Supertonic speech by default, with optional Qwen3-TTS, NeuTTS, Inflect, Inworld, OpenAI-compatible, xAI, IndexTTS, and other backends.
+- Automatic listen-after-speak, stop phrases, idle termination, device selection, and optional barge-in.
+- Shared agent skill for Claude Code, OpenCode, OpenClaw, Hermes, and Codex.
+- Optional Ollama conversation loop and browser dashboard.
+- Optional **AI Sentence Tagger / AI Voice Studio bridge** for the verified 26-voice xAI and 30-voice Google Gemini catalogs with provider-correct sentence direction.
+- Local deterministic validation; GitHub Actions are not required as a release gate.
 
 ## Quick start
 
@@ -60,19 +48,21 @@ chmod +x setup.sh
 ./setup.sh
 ```
 
-The interactive installer lets you choose the speech backends and agent integrations. For a non-interactive CPU install:
+For a non-interactive CPU installation:
 
 ```bash
 ./setup.sh --cpu
 ```
 
-The installed Supertonic service listens on `:8766`. Export the endpoint explicitly so direct `tts.sh` invocations and inherited agent shells use the same port:
+The managed Supertonic service listens on `:8766`. Export the endpoint in the shell that starts the agent:
 
 ```bash
 export SUPERTONIC_URL=http://127.0.0.1:8766
+export TTS_ENGINE=supertonic
+export TTS_QUALITY=normal
 ```
 
-Then verify the stack:
+Verify the installed stack:
 
 ```bash
 ~/.config/opencode/skills/talk/talk.sh status
@@ -82,58 +72,122 @@ Then verify the stack:
 
 ### Windows PowerShell
 
-<p align="center">
-  <img src="windows/assets/voicemode-logo.svg" alt="Local VoiceMode LLM logo" width="128">
-</p>
-
 ```powershell
 git clone https://github.com/groxaxo/Local-VoiceMode-LLM.git
 cd Local-VoiceMode-LLM
 .\setup.ps1
 ```
 
-Prerequisites:
+Recommended prerequisites:
 
 ```powershell
 winget install --id Git.Git
 winget install --id Python.Python.3.12
 winget install --id Microsoft.VCRedist.2015+.x64
-winget install --id Gyan.FFmpeg   # recommended playback option
+winget install --id Gyan.FFmpeg
 ```
 
-For a graphical component selector and service manager:
+Graphical component selector and service manager:
 
 ```powershell
 .\windows\VoiceModeManager.ps1
 ```
 
-Prebuilt native Windows executables are included in [`dist/windows/`](dist/windows/):
+Prebuilt Windows launchers are available under [`dist/windows/`](dist/windows/). See [Windows setup](docs/windows.md).
 
-```powershell
-.\dist\windows\LocalVoiceModeInstaller.exe
-.\dist\windows\LocalVoiceModeManager.exe
+## Conversation protocol
+
+Initial turn:
+
+```bash
+transcript="$(talk.sh listen)"
 ```
 
-Verify the installed services:
+Subsequent turns:
 
-```powershell
-& "$env:USERPROFILE\.config\opencode\skills\talk\talk.ps1" status
-& "$env:USERPROFILE\.config\opencode\skills\talk\talk.ps1" devices
+```bash
+transcript="$(talk.sh speak "Assistant reply")"
 ```
 
-See the full platform guides in [`docs/installation.md`](docs/installation.md) and [`docs/windows.md`](docs/windows.md).
+With `TALK_AUTO_LISTEN=1`, `speak` synthesizes and plays the reply, emits the ready cue, records the next turn, transcribes it, and prints the next transcript to stdout. Empty stdout is the clean session-end signal.
 
-## What the installer creates
+Do not call `listen` again after `speak`; that opens a duplicate recording cycle.
 
-| Component | Default location | Startup mechanism |
+One-way notification:
+
+```bash
+TALK_AUTO_LISTEN=0 talk.sh speak "The build completed successfully."
+```
+
+## Supported agents
+
+| Agent | Installed skill path |
+|---|---|
+| Claude Code | `~/.claude/skills/talk/` |
+| OpenCode CLI | `~/.config/opencode/skills/talk/` |
+| OpenClaw | `~/.openclaw/skills/talk/` |
+| Hermes Agent | `~/.hermes/skills/talk/` |
+| Codex | `~/.codex/skills/talk/` |
+
+The canonical agent contract is [`skill/SKILL.md`](skill/SKILL.md).
+
+## TTS choices
+
+| Path | Location | Selection |
 |---|---|---|
-| Voice environment | `~/.config/opencode/tts-venv/` | on demand |
-| Parakeet backend | `~/.config/opencode/parakeet-stt/` | launchd / systemd user service / Task Scheduler |
-| Supertonic backend | `~/.config/opencode/supertonic-tts/` | launchd / systemd user service / Task Scheduler |
-| Canonical talk skill | `~/.config/opencode/skills/talk/` | invoked by the agent |
-| TTS wrapper | `~/.config/opencode/tts.sh` | invoked by `talk.sh` |
+| Supertonic 3 | local ONNX/MLX | `TTS_ENGINE=supertonic` |
+| Supertonic 2 service | local ONNX, `:8880` | `TTS_ENGINE=supertonic` plus alternate URL |
+| Qwen3-TTS | local MLX service | `TTS_ENGINE=qwen` or `qwen-lazy` |
+| NeuTTS | local GGUF service | `TTS_ENGINE=neutts` |
+| Inflect Nano | local, English only | `TTS_ENGINE=inflect` |
+| OpenAI-compatible TTS | LAN or hosted | `TTS_ENGINE=openai` |
+| Inworld | hosted | `TTS_ENGINE=inworld` |
+| Direct xAI | hosted | `TTS_ENGINE=xai` |
+| IndexTTS | Windows CUDA service | `TTS_ENGINE=indextts` in `talk.ps1` |
+| AI Sentence Tagger / Voice Studio | local companion; xAI or Google synthesis | override `TTS_SH` |
 
-Re-running the installer is non-destructive by default. Existing service definitions are preserved unless `--force` or `-Force` is used.
+Exact Unix fallback order, credentials, and provider limits are in [Providers](docs/providers.md).
+
+## Verified xAI and Google Gemini voices
+
+The optional companion bridge reuses the exact provider implementation from AI Sentence Tagger or AI Voice Studio instead of maintaining a second catalog in shell code.
+
+| Provider | Built-in voices | Default | Direction semantics | Output used by VoiceMode |
+|---|---:|---|---|---|
+| xAI | 26 | `eve` | fixed 14 inline + 13 wrapping tags | WAV 48 kHz |
+| Google Gemini | 30 | `Kore` | 16 common examples plus creative English direction | WAV 24 kHz |
+
+Google's 16 examples are not an exhaustive allowlist. The companion handles canonical voice casing, exact source preservation, lexical tag boundaries, Google Interactions responses, strict base64, and PCM-to-WAV conversion.
+
+Install the bridge:
+
+```bash
+bash integrations/ai-sentence-tagger/install.sh
+```
+
+Use Google Gemini:
+
+```bash
+export TTS_SH="$HOME/.config/opencode/ai-tts-provider/tts-provider.sh"
+export AI_TTS_URL=http://127.0.0.1:8000
+export AI_TTS_PROVIDER=google
+export AI_TTS_VOICE=Kore
+
+~/.config/opencode/skills/talk/talk.sh speak "The deployment completed."
+```
+
+Use xAI:
+
+```bash
+export TTS_SH="$HOME/.config/opencode/ai-tts-provider/tts-provider.sh"
+export AI_TTS_URL=http://127.0.0.1:8000
+export AI_TTS_PROVIDER=xai
+export AI_TTS_VOICE=eve
+```
+
+Setting `TTS_SH` replaces the built-in Unix dispatcher for that process. Unset it to restore the normal local-first fallback graph.
+
+Full guide: [AI provider bridge](integrations/ai-sentence-tagger/README.md).
 
 ## How it works
 
@@ -144,76 +198,73 @@ Microphone
 Silero VAD ──► PCM WAV ──► Parakeet STT :5093
                                   │
                                   ▼
-                        Agent or local LLM
+                         Agent / local LLM
                                   │
                                   ▼
-                   TTS dispatcher and fallbacks
-                     │         │          │
-                     ▼         ▼          ▼
-               Supertonic   local opt.   remote opt.
-                  :8766
-                     │
-                     ▼
-                 playback ──► next turn
+                   talk.sh / talk.ps1 orchestrator
+                         │                 │
+                         ▼                 ▼
+                 built-in tts.sh     optional TTS_SH bridge
+                         │                 │
+                         └───────┬─────────┘
+                                 ▼
+                              playback
+                                 │
+                                 ▼
+                            next user turn
 ```
 
-The recorder uses fixed-size audio frames, a bounded ring buffer, pre-speech padding, and trailing-silence endpointing. Each completed utterance is normalized, saved as a mono WAV, and posted to the OpenAI-compatible Parakeet transcription endpoint.
+The detailed recorder coordinates, pre-warmed microphone path, barge-in model, platform differences, and service boundaries are documented in [Architecture](docs/architecture.md).
 
-During a normal agent conversation:
+## Configuration
 
-1. `talk.sh listen` records and prints the first user utterance.
-2. The agent produces a concise spoken reply.
-3. `talk.sh speak "reply"` synthesizes and plays it.
-4. With `TALK_AUTO_LISTEN=1`, the microphone is pre-warmed and opens for the next turn automatically.
-5. Empty stdout means the voice session ended; the agent should stop the loop.
+The scripts read the environment of the process that launches them. They do **not** automatically source `.env.example`.
 
-The detailed data flow and platform differences are documented in [`docs/architecture.md`](docs/architecture.md).
+Recommended local baseline:
 
-## Supported agents
+```bash
+export STT_ENGINE=local
+export STT_URL=http://127.0.0.1:5093/v1/audio/transcriptions
+export STT_MODEL=parakeet-tdt-0.6b-v3
+export TTS_ENGINE=supertonic
+export SUPERTONIC_URL=http://127.0.0.1:8766
+export TTS_QUALITY=normal
+export VAD_THRESHOLD=0.5
+export VAD_MIN_SILENCE_MS=700
+export TALK_IDLE_TIMEOUT_S=300
+```
 
-The same skill is installed for each selected agent:
+Important settings:
 
-| Agent | Skill location |
+| Variable | Purpose |
 |---|---|
-| Claude Code | `~/.claude/skills/talk/` |
-| OpenCode CLI | `~/.config/opencode/skills/talk/` |
-| OpenClaw | `~/.openclaw/skills/talk/` |
-| Hermes Agent | `~/.hermes/skills/talk/` |
-| Codex | `~/.codex/skills/talk/` |
+| `STT_ENGINE` | Unix STT route: `local` or `remote` |
+| `STT_URL` / `STT_MODEL` | Local transcription endpoint and model |
+| `STT_REMOTE_URL` / `STT_API_KEY` | Remote OpenAI-compatible transcription |
+| `TTS_ENGINE` | Built-in Unix/Windows primary TTS selection |
+| `TTS_SH` | Unix implementation override; used by the AI provider bridge |
+| `SUPERTONIC_URL` / `SUPERTONIC_VOICE` | Local Supertonic endpoint and voice |
+| `TTS_QUALITY` | `normal` for 8 steps or `high` for 20 steps |
+| `VAD_THRESHOLD` | Speech sensitivity |
+| `VAD_MIN_SILENCE_MS` | Silence required to close a turn |
+| `MIC_QUERY` | Input-device name substring |
+| `TALK_AUTO_LISTEN` | Reopen/activate the microphone after playback |
+| `TALK_BARGE_IN` | Interrupt playback when speech is detected |
+| `TALK_STOP_PHRASES` | Pipe-separated spoken session-stop phrases |
 
-Typical commands:
+Start from [`.env.example`](.env.example) and copy only the variables needed by your launcher or service manager.
 
-```bash
-talk.sh listen                         # record and transcribe one turn
-talk.sh speak "Hello"                 # synthesize; auto-listen when enabled
-talk.sh status                         # backend and configuration health
-talk.sh devices                        # list devices and selected microphone
-talk.sh pick                           # save an interactive microphone choice
-talk.sh loop                           # standalone terminal loop
-```
-
-For one-way read-aloud without reopening the microphone:
-
-```bash
-TALK_AUTO_LISTEN=0 talk.sh speak "Build completed successfully."
-```
-
-## Talk to an Ollama model
-
-The recommended integration uses the Ollama HTTP API and does not rebuild Ollama:
+## Ollama voice loop
 
 ```bash
 bash integrations/ollama/install.sh
 ollama-voice
 ollama-voice llama3.2
-ollama-voice llama3.2 --text
 ```
 
-It preserves conversation history, can speak completed sentences while the model is still generating, and filters reasoning blocks from spoken output. See [`integrations/ollama/README.md`](integrations/ollama/README.md).
+It preserves conversation history, can speak completed sentences while generation continues, and filters reasoning blocks from spoken output. See [Ollama integration](integrations/ollama/README.md).
 
-## Web dashboard
-
-Start the local dashboard:
+## Dashboard
 
 ```bash
 cd frontend
@@ -221,113 +272,44 @@ bash start.sh
 # http://127.0.0.1:7862
 ```
 
-The dashboard provides:
+The dashboard tests Supertonic and Parakeet, exposes VAD controls, and reports backend health. Linux service restart controls require `systemd --user`; synthesis and transcription tests work wherever the configured endpoints are reachable.
 
-- Supertonic synthesis testing
-- Parakeet microphone and upload transcription
-- VAD threshold, padding, silence, and duration controls
-- Backend health checks
-- Linux/systemd compute toggles
+## Validation
 
-The GPU restart controls are Linux/systemd-specific. TTS and STT testing work wherever the backend URLs are reachable.
-
-## Configuration
-
-Set variables in the shell that launches the agent, or prefix a single command. Start from [`.env.example`](.env.example), but remember that shell scripts do not automatically import an arbitrary `.env` file.
-
-Recommended local baseline:
+Local checks do not require GitHub Actions:
 
 ```bash
-export STT_URL=http://127.0.0.1:5093/v1/audio/transcriptions
-export STT_MODEL=parakeet-tdt-0.6b-v3
-export SUPERTONIC_URL=http://127.0.0.1:8766
-export TTS_ENGINE=supertonic
-export TTS_QUALITY=normal
-export VAD_THRESHOLD=0.5
-export VAD_MIN_SILENCE_MS=700
-export TALK_IDLE_TIMEOUT_S=300
+python -m compileall -q service frontend tests integrations
+python -m pytest -q
+bash -n service/talk.sh service/tts.sh
+bash -n integrations/ai-sentence-tagger/tts-provider.sh
+bash -n integrations/ai-sentence-tagger/install.sh
+python -m unittest tests.test_ai_tts_provider -v
 ```
 
-Important variables:
-
-| Variable | Purpose |
-|---|---|
-| `STT_ENGINE` | `local` or `remote` on the Unix orchestrator |
-| `STT_URL` / `STT_MODEL` | Local transcription endpoint and model id |
-| `STT_REMOTE_URL` / `STT_API_KEY` | Remote OpenAI-compatible transcription |
-| `TTS_ENGINE` | Primary TTS engine |
-| `SUPERTONIC_URL` | Supertonic endpoint; installed default is `http://127.0.0.1:8766` |
-| `SUPERTONIC_VOICE` | `F1`–`F5` or `M1`–`M5` |
-| `TTS_QUALITY` | `normal` for 8 steps or `high` for 20 steps |
-| `VAD_THRESHOLD` | Speech sensitivity |
-| `VAD_MIN_SILENCE_MS` | Silence required to close a turn |
-| `MIC_QUERY` | Microphone name substring |
-| `TALK_AUTO_LISTEN` | Reopen the microphone after playback |
-| `TALK_BARGE_IN` | Interrupt playback when speech is detected |
-| `TALK_STOP_PHRASES` | Pipe-separated spoken session-stop phrases |
-
-Provider-specific variables and exact fallback order are in [`docs/providers.md`](docs/providers.md).
-
-## Local and remote TTS choices
-
-| Engine | Location | Status |
-|---|---|---|
-| Supertonic 3 | local ONNX, `:8766` | default, installed automatically |
-| NeuTTS | local GGUF, `:8020` | optional |
-| Inflect Nano | local, `:8030` | optional, English only |
-| Qwen3-TTS | local MLX | optional, Apple Silicon-oriented |
-| OpenAI-compatible TTS | remote or LAN | optional |
-| Inworld | remote | optional, expressive steering |
-| xAI | remote | optional fallback |
-| Supertonic 2 | local ONNX, `:8880` | optional service; see its integration guide |
-
-Supertonic 2 currently uses the same API shape as Supertonic 3. Until the dispatcher exposes a dedicated alias, select it by pointing the Supertonic engine at port `8880`:
-
-```bash
-TTS_ENGINE=supertonic \
-SUPERTONIC_URL=http://127.0.0.1:8880 \
-talk.sh speak "Hello from Supertonic 2"
-```
-
-## Benchmarks
-
-Measured on an Intel Core i7-12700KF, CPU-only, median of five runs:
-
-| Stage | Workload | Measured latency |
-|---|---|---:|
-| Silero VAD | 32 ms frame | 0.09 ms |
-| Parakeet STT | 2.4 s audio | 307 ms |
-| Parakeet STT | 13.4 s audio | 729 ms |
-| Supertonic 3 | 2.4 s output, 8 steps | 1.39 s |
-| Supertonic 3 | 13.4 s output, 8 steps | 5.18 s |
-
-These measurements describe the benchmark machine, not a universal latency guarantee. Reproduce them against your own installed services:
-
-```bash
-python benchmarks/run_benchmark.py
-```
-
-Additional results are in [`benchmarks/README.md`](benchmarks/README.md) and [`benchmarks/TTS_BACKENDS.md`](benchmarks/TTS_BACKENDS.md).
-
-## Operational limits
-
-- A single microphone cannot distinguish the user from a television, another person, or speaker bleed. Tune `VAD_THRESHOLD` and use headphones when necessary.
-- Barge-in needs echo cancellation or careful microphone placement.
-- Remote engines send text or audio to the selected provider; the default local path does not.
-- The dashboard's service-restart controls assume Linux `systemd --user`.
-- Windows currently has a smaller provider surface than the Unix shell implementation.
+Physical microphone, speaker, model-download, OS service-manager, and paid-provider checks remain manual release tests.
 
 ## Documentation
 
 | Guide | Contents |
 |---|---|
-| [`docs/README.md`](docs/README.md) | documentation index |
-| [`docs/installation.md`](docs/installation.md) | platform setup, flags, services, uninstall |
-| [`docs/windows.md`](docs/windows.md) | Windows installer, manager app, prerequisites, and diagnostics |
-| [`docs/architecture.md`](docs/architecture.md) | runtime design and data flow |
-| [`docs/providers.md`](docs/providers.md) | TTS/STT engines, credentials, fallback policy |
-| [`docs/troubleshooting.md`](docs/troubleshooting.md) | diagnosis and recovery commands |
-| [`skill/SKILL.md`](skill/SKILL.md) | agent-facing talk-loop contract |
+| [Documentation index](docs/README.md) | complete guide map |
+| [Installation](docs/installation.md) | platform setup, services, upgrades, uninstall |
+| [Windows](docs/windows.md) | PowerShell orchestrator, manager, and prerequisites |
+| [Architecture](docs/architecture.md) | runtime design and data flow |
+| [Providers](docs/providers.md) | engines, credentials, bridge, and fallback policy |
+| [AI provider bridge](docs/ai-provider-bridge.md) | shared xAI/Gemini integration architecture |
+| [Troubleshooting](docs/troubleshooting.md) | diagnosis and recovery |
+| [Benchmarks](benchmarks/README.md) | reproducible latency tests |
+
+## Operational boundaries
+
+- The default VAD/STT/TTS path stays local; remote engines send reply text or recorded audio to the selected endpoint.
+- Barge-in is acoustic detection, not echo cancellation. Prefer headphones when speakers bleed into the microphone.
+- Windows and Unix orchestrators are separate implementations; do not assume feature parity.
+- The AI provider bridge currently integrates directly with Unix/macOS `talk.sh`; its Python client is portable, but the Windows dispatcher is not automatically redirected.
+- A companion AI Sentence Tagger/Voice Studio request is stateless and does not create persistent Studio projects.
+- Never commit API credentials or include them in prompts and logs.
 
 ## Project layout
 
@@ -343,24 +325,16 @@ Local-VoiceMode-LLM/
 ├── windows/
 │   ├── talk.ps1
 │   └── VoiceModeManager.ps1
-├── dist/windows/                 # prebuilt Windows installer and manager EXEs
-├── skill/SKILL.md
-├── frontend/
 ├── integrations/
+│   ├── ai-sentence-tagger/
 │   ├── ollama/
 │   └── supertonic2/
+├── skill/SKILL.md
+├── frontend/
 ├── docs/
 ├── benchmarks/
 └── tests/
 ```
-
-## Related projects
-
-- [Parakeet TDT FastAPI OpenAI server](https://github.com/groxaxo/parakeet-tdt-0.6b-v3-fastapi-openai)
-- [Supertonic Express 3](https://github.com/groxaxo/supertonic-express-3)
-- [Supertonic 3 v2 model assets](https://github.com/groxaxo/supertonic-3-v2)
-- [Qwen3-TTS OpenAI FastAPI](https://github.com/groxaxo/Qwen3-TTS-Openai-Fastapi)
-- [OpenVoiceApp](https://github.com/groxaxo/OpenVoiceApp)
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,13 +7,15 @@ This directory contains the operational and technical reference for Local VoiceM
 | Guide | Use it when |
 |---|---|
 | [Installation](installation.md) | Installing, upgrading, selecting integrations, managing services, or uninstalling |
-| [Windows installer and manager](windows.md) | Installing Windows prerequisites, selecting components, or managing scheduled services |
-| [Apple Silicon MLX setup and repair](macos-repair.md) | Installing, validating, benchmarking, or forcing Supertonic MLX/ONNX on a Mac |
+| [Windows installer and manager](windows.md) | Installing Windows prerequisites, selecting components, IndexTTS, or managing scheduled services |
+| [Apple Silicon MLX setup and repair](macos-repair.md) | Installing, validating, benchmarking, or forcing MLX/ONNX on a Mac |
 | [Troubleshooting](troubleshooting.md) | A microphone, backend, playback path, provider, or service is not working |
-| [Providers](providers.md) | Choosing local or remote STT/TTS and understanding fallback behavior |
-| [Architecture](architecture.md) | Reviewing the runtime design, data flow, boundaries, ports, and platform differences |
+| [Providers](providers.md) | Choosing local/remote STT or TTS, credentials, and fallback behavior |
+| [Shared AI provider bridge](ai-provider-bridge.md) | Reusing AI Sentence Tagger / AI Voice Studio for verified xAI and Gemini voices |
+| [Architecture](architecture.md) | Reviewing runtime design, data flow, boundaries, ports, and platform differences |
 | [Agent skill contract](../skill/SKILL.md) | Integrating the voice loop into Claude Code, OpenCode, OpenClaw, Hermes, or Codex |
 | [Ollama integration](../integrations/ollama/README.md) | Talking directly to an Ollama model |
+| [AI Sentence Tagger integration](../integrations/ai-sentence-tagger/README.md) | Installing and operating the xAI/Google companion bridge |
 | [Supertonic 2 integration](../integrations/supertonic2/README.md) | Installing the optional Supertonic 2 service |
 | [Benchmarks](../benchmarks/README.md) | Reproducing latency and realtime-factor measurements |
 
@@ -29,10 +31,14 @@ Silero VAD ──► WAV ──► Parakeet STT :5093
                         agent / local LLM
                                │
                                ▼
-                         TTS dispatcher
-                               │
-                               ▼
-                         audio playback
+                         talk orchestrator
+                         │             │
+                         ▼             ▼
+                   built-in tts.sh   optional TTS_SH bridge
+                         │             │
+                         └──────┬──────┘
+                                ▼
+                          audio playback
 ```
 
 Default local services:
@@ -40,23 +46,23 @@ Default local services:
 | Service | URL | Default runtime |
 |---|---|---|
 | Parakeet STT | `http://127.0.0.1:5093` | ONNX CPU by default |
-| Supertonic 3 TTS | `http://127.0.0.1:8766` | Apple Silicon: MLX first with ONNX fallback; other CPU hosts: ONNX |
+| Supertonic 3 TTS | `http://127.0.0.1:8766` | Apple Silicon: MLX first with ONNX fallback; other hosts: ONNX |
 | Dashboard | `http://127.0.0.1:7862` | CPU |
-| Ollama, when used | `http://127.0.0.1:11434` | User-selected |
+| Ollama, when used | `http://127.0.0.1:11434` | user-selected |
+| AI Sentence Tagger / Voice Studio, when used | `http://127.0.0.1:8000` | user-selected companion |
 
-## Documentation principles
+## Routing concepts
 
-The project documentation separates three concepts that are easy to confuse:
+The documentation distinguishes four layers:
 
-1. **Installed backend service** — the server process and port.
-2. **Orchestrator** — `talk.sh` on Unix or `talk.ps1` on Windows.
-3. **Agent skill** — the instructions that tell an AI agent how to use the orchestrator.
+1. **Backend service** — the STT/TTS server and port.
+2. **Built-in dispatcher** — `service/tts.sh`, selected through `TTS_ENGINE` on Unix.
+3. **Implementation override** — `TTS_SH`, used by the shared AI provider bridge.
+4. **Agent orchestrator/skill** — `talk.sh`, `talk.ps1`, and the instructions an agent follows.
 
-A healthy backend does not guarantee that the orchestrator is pointing at the same port. When diagnosing a problem, verify both the service and the effective environment used by the launching shell.
+A healthy backend does not prove that the orchestrator is using the same endpoint. Always inspect the effective environment of the process that launches the agent.
 
 ## Recommended local environment
-
-The installer places Supertonic on `:8766`. Export that endpoint in the shell that starts the agent:
 
 ```bash
 export STT_URL=http://127.0.0.1:5093/v1/audio/transcriptions
@@ -68,17 +74,10 @@ export VAD_THRESHOLD=0.5
 export VAD_MIN_SILENCE_MS=700
 ```
 
-The repository includes [`.env.example`](../.env.example) as a reference. Shell scripts do not automatically source arbitrary `.env` files; export the variables, source the file explicitly, or place the values in the shell/session configuration used to launch the agent.
+The repository includes [`.env.example`](../.env.example) as a reference. Shell scripts do not automatically source arbitrary `.env` files.
 
 ## Support boundary
 
-The core supported path is:
+The core supported path is local Silero VAD, local Parakeet STT, local Supertonic TTS, and the platform-native orchestrator on macOS, Linux, or Windows.
 
-- local Silero VAD
-- local Parakeet ONNX STT
-- local Supertonic 3 TTS
-  - Apple Silicon: native MLX with verified ONNX CPU fallback
-  - Linux/Intel Mac/Windows: ONNX, with optional CUDA where supported
-- macOS, Linux, or Windows installation
-
-Optional providers and integrations are maintained as secondary paths. Their availability, authentication, response schemas, and latency can change independently of the local stack.
+Optional providers and integrations are secondary paths. Their authentication, schemas, latency, and availability can change independently. The AI provider bridge avoids duplicating xAI/Gemini contracts by reading catalogs and synthesizing through a versioned companion service.

--- a/docs/ai-provider-bridge.md
+++ b/docs/ai-provider-bridge.md
@@ -1,0 +1,85 @@
+# Shared AI TTS provider bridge
+
+Local VoiceMode LLM remains local-first by default. The optional AI provider bridge connects the Unix/macOS conversation loop to a local **AI Sentence Tagger** or **AI Voice Studio** service when provider-correct xAI or Google Gemini direction is required.
+
+## Why use a companion service?
+
+The built-in `service/tts.sh` is a lightweight shell dispatcher. The companion projects provide a deeper provider contract:
+
+- verified 26-voice xAI and 30-voice Gemini catalogs;
+- fixed xAI grammar versus creative Gemini direction semantics;
+- exact source-preservation validation;
+- local OpenAI-compatible LLM tagging;
+- Google Interactions audio extraction and PCM-to-WAV conversion;
+- provider-aware manifests, REST, CLI, and MCP.
+
+The bridge reuses that implementation through `/api/process/json` instead of copying the catalogs into Local VoiceMode.
+
+## Data flow
+
+```text
+agent reply
+    │
+    ▼
+talk.sh
+    │ TTS_SH override
+    ▼
+tts-provider.sh
+    │ POST /api/process/json
+    ▼
+AI Sentence Tagger / AI Voice Studio :8000
+    ├── local OpenAI-compatible tagger
+    ├── provider validator
+    └── xAI or Google synthesis
+             │
+             ▼
+       base64 provider WAV
+             │
+             ▼
+strict decode + atomic local WAV
+             │
+             ▼
+playback / pre-warmed listen / barge-in
+```
+
+## Install
+
+```bash
+bash integrations/ai-sentence-tagger/install.sh
+```
+
+## Google example
+
+```bash
+export TTS_SH="$HOME/.config/opencode/ai-tts-provider/tts-provider.sh"
+export AI_TTS_URL=http://127.0.0.1:8000
+export AI_TTS_PROVIDER=google
+export AI_TTS_VOICE=Kore
+export AI_TTS_STYLE_PROMPT='Clear, friendly technical assistant'
+
+~/.config/opencode/skills/talk/talk.sh speak "The validation passed."
+```
+
+## xAI example
+
+```bash
+export TTS_SH="$HOME/.config/opencode/ai-tts-provider/tts-provider.sh"
+export AI_TTS_URL=http://127.0.0.1:8000
+export AI_TTS_PROVIDER=xai
+export AI_TTS_VOICE=eve
+
+~/.config/opencode/skills/talk/talk.sh speak "The validation passed."
+```
+
+## Important boundary
+
+`TTS_SH` is an implementation override, not a new `TTS_ENGINE` value. Once set, the bridge replaces `service/tts.sh` for that process. Unset `TTS_SH` to restore the repository's built-in local-first fallback graph.
+
+## Companion security boundary
+
+The bridge contains no xAI or Google credentials. Provider keys and tagging-model configuration stay in the companion service. Bind it to loopback or protect it with a private reverse proxy; `AI_TTS_TOKEN` adds an optional bearer header.
+
+## More detail
+
+- [Integration guide](../integrations/ai-sentence-tagger/README.md)
+- [Provider and fallback reference](providers.md)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -6,44 +6,57 @@ Local VoiceMode LLM is designed around a local speech path:
 - Parakeet STT on `127.0.0.1:5093`
 - Supertonic TTS on `127.0.0.1:8766`
 
-Remote providers are optional. Use them when a machine is too slow for local synthesis, when a specific hosted voice is required, or when the speech service runs on another machine on the LAN.
+Remote providers and companion services are optional. Use them when a specific hosted voice is required, a slow machine needs offload, or provider-correct sentence direction adds value.
 
-## Choose a deployment pattern
+## Two TTS routing mechanisms
 
-| Situation | STT recommendation | TTS recommendation |
-|---|---|---|
-| Modern desktop or laptop | local Parakeet | local Supertonic |
-| GPU is reserved for the LLM | local Parakeet on CPU | local Supertonic on CPU |
-| Old or heavily loaded CPU | keep Parakeet local first | remote OpenAI-compatible TTS |
-| Air-gapped or privacy-sensitive system | local only | local only |
-| Expressive hosted voice is required | local Parakeet | Inworld or another selected provider |
-| Speech runs on another LAN host | OpenAI-compatible remote STT URL | OpenAI-compatible TTS URL |
+The Unix orchestrator supports two distinct routing layers.
 
-Parakeet transcription is normally the lighter stage. Offload TTS first when conversational latency is the problem.
+### 1. Built-in dispatcher
 
-## Environment loading
+When `TTS_SH` is unset, `talk.sh` runs `service/tts.sh`. `TTS_ENGINE` chooses the primary engine and its explicit fallback chain.
 
-The scripts read environment variables from the process that launches them. They do not automatically load the repository's `.env.example` or an arbitrary `.env` file.
+### 2. Implementation override
 
-Recommended local baseline:
+When `TTS_SH` points to another executable, `talk.sh` invokes that implementation instead. The AI Sentence Tagger / AI Voice Studio bridge uses this mechanism.
+
+```bash
+export TTS_SH="$HOME/.config/opencode/ai-tts-provider/tts-provider.sh"
+```
+
+An override bypasses the built-in dispatcher; `TTS_ENGINE` fallback does not run automatically.
+
+## Recommended local baseline
 
 ```bash
 export STT_ENGINE=local
 export STT_URL=http://127.0.0.1:5093/v1/audio/transcriptions
 export STT_MODEL=parakeet-tdt-0.6b-v3
-
 export TTS_ENGINE=supertonic
 export SUPERTONIC_URL=http://127.0.0.1:8766
 export TTS_QUALITY=normal
 ```
 
-The explicit `SUPERTONIC_URL` matters because the managed installer uses port `8766`, while older/manual layouts may use `8765`.
+The scripts inherit environment variables from their launcher. They do not automatically load `.env.example`.
+
+## Deployment choices
+
+| Situation | STT recommendation | TTS recommendation |
+|---|---|---|
+| Modern desktop or laptop | local Parakeet | local Supertonic |
+| GPU reserved for the LLM | local Parakeet on CPU | local Supertonic on CPU |
+| Apple Silicon with separate service | local Parakeet | Qwen3-TTS or Supertonic MLX |
+| Old or heavily loaded CPU | local first | remote OpenAI-compatible TTS |
+| Air-gapped or privacy-sensitive | local only | local only |
+| Expressive hosted voice | local Parakeet | Inworld, xAI, or companion bridge |
+| Verified xAI/Gemini catalogs and sentence direction | local Parakeet | AI Sentence Tagger / Voice Studio bridge |
+| Speech service on a LAN host | configurable URL | OpenAI-compatible or bridge URL |
 
 ## Local TTS engines
 
 ### Supertonic 3
 
-Supertonic 3 is the supported default backend installed by `setup.sh` and `setup.ps1`.
+Default installed backend:
 
 ```bash
 export TTS_ENGINE=supertonic
@@ -52,67 +65,47 @@ export SUPERTONIC_VOICE=F4
 export TTS_QUALITY=normal
 ```
 
-| Variable | Recommended/default behavior | Purpose |
-|---|---|---|
-| `SUPERTONIC_URL` | set explicitly to `http://127.0.0.1:8766` for the managed install | API base URL |
-| `SUPERTONIC_VOICE` | `F4` | `F1`–`F5` or `M1`–`M5` |
-| `TTS_QUALITY` | recommended `normal`; the current low-level script falls back to `high` when unset | `normal` = 8 steps, `high` = 20 steps |
-| `SUPERTONIC_STEPS` | derived from quality | explicit step override from 1–20 |
-| `SUPERTONIC_SPEED` | `1.0` | synthesis speed multiplier |
-| `TTS_FADE_MS` | `6` | edge fade used to reduce clicks |
+| Variable | Meaning |
+|---|---|
+| `SUPERTONIC_URL` | Managed installation endpoint; normally `:8766` |
+| `SUPERTONIC_VOICE` | `F1`–`F5` or `M1`–`M5` |
+| `TTS_QUALITY` | `normal` = 8 steps; `high` = 20 steps |
+| `SUPERTONIC_STEPS` | Explicit 1–20 step override |
+| `SUPERTONIC_SPEED` | Synthesis speed multiplier |
+| `TTS_FADE_MS` | Edge fade used to reduce clicks |
 
-For low-latency conversation, set `TTS_QUALITY=normal` explicitly.
+### Supertonic 2
 
-### Supertonic 2 service
-
-The optional installer creates a second OpenAI-compatible Supertonic service on `:8880`:
+The optional service uses an OpenAI-compatible endpoint on `:8880`:
 
 ```bash
 bash integrations/supertonic2/install.sh
-```
-
-The current TTS dispatcher does **not** expose a dedicated `supertonic2` engine alias. Select the compatible service by retaining the `supertonic` engine and changing its URL:
-
-```bash
 TTS_ENGINE=supertonic \
 SUPERTONIC_URL=http://127.0.0.1:8880 \
-talk.sh speak "Hello from Supertonic two"
+talk.sh speak "Hello from Supertonic 2"
 ```
 
-This gives direct access to the service. It does not automatically fall back to the Supertonic 3 URL if `:8880` is unavailable; change the URL back to `:8766` or use your own wrapper/proxy for multi-endpoint failover.
+There is no dedicated `supertonic2` dispatcher value; the URL chooses the compatible service.
 
 ### NeuTTS
-
-NeuTTS is an optional local GGUF service:
 
 ```bash
 export TTS_ENGINE=neutts
 export NEUTTS_URL=http://127.0.0.1:8020
 ```
 
-Language-specific model variables are available for English, Spanish, German, and French:
-
-- `NEUTTS_MODEL`
-- `NEUTTS_MODEL_ES`
-- `NEUTTS_MODEL_DE`
-- `NEUTTS_MODEL_FR`
-
-The backend is not installed by the main setup scripts.
+Language-specific model variables are available for English, Spanish, German, and French.
 
 ### Inflect Nano
-
-Inflect Nano is an optional, experimental English-only endpoint:
 
 ```bash
 export TTS_ENGINE=inflect
 export INFLECT_URL=http://127.0.0.1:8030
 ```
 
-For non-English text it declines the request so the configured fallback chain can continue.
+Inflect is experimental and English-only. It declines other languages so the fallback chain can continue.
 
 ### Qwen3-TTS
-
-Qwen3-TTS is an optional local MLX/OpenAI-compatible backend, primarily for Apple Silicon. Install and operate it separately through the Qwen3-TTS server project.
 
 ```bash
 export TTS_ENGINE=qwen
@@ -120,13 +113,108 @@ export QWEN_TTS_QUALITY=hq
 export QWEN_TTS_VOICE=vivian
 ```
 
-| Quality | Default URL | Intended use |
-|---|---|---|
-| `fast` | `http://127.0.0.1:18881` | lower-latency 0.6B server |
-| `hq` | `http://127.0.0.1:18882` | always-on 1.7B server |
-| `lazy` | `http://127.0.0.1:18883` | 1.7B server started on demand |
+| Quality | Default URL |
+|---|---|
+| `fast` | `http://127.0.0.1:18881` |
+| `hq` | `http://127.0.0.1:18882` |
+| `lazy` | `http://127.0.0.1:18883` |
 
-Override `QWEN_TTS_URL` to bypass quality-based URL selection.
+Set `QWEN_TTS_URL` to bypass quality-based URL selection.
+
+### Windows IndexTTS
+
+The Windows PowerShell orchestrator supports an IndexTTS CUDA service:
+
+```powershell
+$env:TTS_ENGINE = "indextts"
+$env:INDEXTTS_URL = "http://127.0.0.1:7863"
+$env:INDEXTTS_REF_AUDIO = "C:\voices\reference.wav"
+.\windows\talk.ps1 speak "Hello"
+```
+
+A valid reference WAV is required. This path is implemented by `windows/talk.ps1`, not the Unix shell dispatcher.
+
+## Shared AI Sentence Tagger / AI Voice Studio bridge
+
+The optional bridge reuses a local companion service as the source of truth for xAI and Google Gemini voices, sentence direction, validation, and synthesis.
+
+Supported contracts:
+
+| Provider | Built-in voices | Default voice | Direction semantics | VoiceMode output |
+|---|---:|---|---|---|
+| xAI | 26 | `eve` | fixed 14 inline + 13 wrapping tags | WAV 48 kHz |
+| Google Gemini | 30 | `Kore` | 16 common examples plus creative English direction | WAV 24 kHz |
+
+Google's 16 examples are non-exhaustive. The companion enforces exact source preservation, literal bracket-cue handling, lexical boundaries, canonical voice casing, and PCM-to-WAV conversion.
+
+### Install
+
+```bash
+bash integrations/ai-sentence-tagger/install.sh
+```
+
+### Select Google
+
+```bash
+export TTS_SH="$HOME/.config/opencode/ai-tts-provider/tts-provider.sh"
+export AI_TTS_URL=http://127.0.0.1:8000
+export AI_TTS_PROVIDER=google
+export AI_TTS_VOICE=Kore
+export AI_TTS_LANGUAGE=auto
+```
+
+### Select xAI
+
+```bash
+export TTS_SH="$HOME/.config/opencode/ai-tts-provider/tts-provider.sh"
+export AI_TTS_URL=http://127.0.0.1:8000
+export AI_TTS_PROVIDER=xai
+export AI_TTS_VOICE=eve
+```
+
+The companion can be either:
+
+- `groxaxo/xai-sentence-tagger`; or
+- `groxaxo/xAI-Voice-Studio`.
+
+Both expose the required stateless `/api/process/json` endpoint. The bridge does not create persistent Studio projects.
+
+### Bridge variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `AI_TTS_URL` | `http://127.0.0.1:8000` | Companion base URL |
+| `AI_TTS_PROVIDER` | `xai` | `xai`, `google`, or `gemini` |
+| `AI_TTS_VOICE` | provider default | Case-insensitive built-in voice |
+| `AI_TTS_SOURCE_LANGUAGE` | language passed by `talk.sh` | Tagging-language override |
+| `AI_TTS_LANGUAGE` | source language | Synthesis language |
+| `AI_TTS_COVERAGE` | `natural` | Direction coverage mode |
+| `AI_TTS_STYLE_PROMPT` | unset | Gemini Director's Notes |
+| `AI_TTS_MODEL` | companion default | Gemini TTS model override |
+| `AI_TTS_TAGGER_MODEL` | companion default | Tagging-model override |
+| `AI_TTS_TAGGER_BASE_URL` | companion default | Tagging endpoint override |
+| `AI_TTS_TOKEN` | unset | Optional bearer token |
+| `AI_TTS_TIMEOUT_SECONDS` | `180` | Request timeout |
+| `AI_TTS_MAX_AUDIO_BYTES` | `100000000` | Decoded-audio limit |
+
+The bridge forces WAV because pre-warmed listening and barge-in expect a single playable file. `AI_TTS_SAMPLE_RATE` is an advanced override and must be supported by the active provider.
+
+### Catalog inspection
+
+```bash
+python3 ~/.config/opencode/ai-tts-provider/tts_provider.py providers
+python3 ~/.config/opencode/ai-tts-provider/tts_provider.py voices --provider google
+python3 ~/.config/opencode/ai-tts-provider/tts_provider.py tags --provider google
+```
+
+### Restore local-first routing
+
+```bash
+unset TTS_SH
+export TTS_ENGINE=supertonic
+```
+
+See [the complete integration guide](../integrations/ai-sentence-tagger/README.md).
 
 ## Remote OpenAI-compatible TTS
 
@@ -136,69 +224,42 @@ The `openai` engine sends the standard speech payload to:
 <OPENAI_TTS_URL>/audio/speech
 ```
 
-It can target OpenAI or another compatible service, including a server on the local network.
-
 ```bash
 export TTS_ENGINE=openai
 export OPENAI_TTS_URL=https://api.openai.com/v1
-export OPENAI_TTS_KEY=...
+export OPENAI_TTS_KEY=replace-me
 export OPENAI_TTS_MODEL=gpt-4o-mini-tts
 export OPENAI_TTS_VOICE=alloy
 export OPENAI_TTS_FORMAT=wav
 ```
 
-`OPENAI_API_KEY` is used when `OPENAI_TTS_KEY` is not set.
-
-| Variable | Low-level default | Purpose |
-|---|---|---|
-| `OPENAI_TTS_URL` | `https://api.openai.com/v1` | API base URL, without `/audio/speech` |
-| `OPENAI_TTS_KEY` | value of `OPENAI_API_KEY` | bearer token |
-| `OPENAI_TTS_MODEL` | `gpt-4o-mini-tts` | provider model id |
-| `OPENAI_TTS_VOICE` | `alloy` | provider voice id |
-| `OPENAI_TTS_FORMAT` | `wav` | requested output format |
-
-For normal playback, replies are split at sentence boundaries, requests are issued in parallel, and audio is played in order as chunks become ready. With `TTS_NO_PLAY=1`, the implementation uses a single request so it can return one file path to the orchestrator.
-
-Provider compatibility is not guaranteed merely because an API is described as OpenAI-compatible. Confirm that it accepts the same field names and returns the requested audio format.
+`OPENAI_API_KEY` is used when `OPENAI_TTS_KEY` is unset. Compatibility is not guaranteed solely because a server advertises an OpenAI-like API; verify fields and returned audio.
 
 ## Inworld TTS
 
-Inworld is an optional hosted engine with per-sentence expressive steering.
-
 ```bash
 export TTS_ENGINE=inworld
-export INWORLD_API_KEY=...
+export INWORLD_API_KEY=replace-with-basic-base64-key
 export INWORLD_TTS_VOICE=Ashley
 export INWORLD_TTS_MODEL=inworld-tts-2
 export INWORLD_STEER=auto
 ```
 
-| Variable | Low-level default | Purpose |
-|---|---|---|
-| `INWORLD_API_KEY` | required | Basic/base64 API credential; `INWORLD_TTS_API` is also read |
-| `INWORLD_TTS_VOICE` | `Ashley` | provider voice id |
-| `INWORLD_TTS_MODEL` | `inworld-tts-2` | model id |
-| `INWORLD_TTS_URL` | Inworld voice endpoint | request URL |
-| `INWORLD_STEER` | `auto` | enable/disable delivery-tag generation |
-| `INWORLD_STEER_PERSONA` | empty | optional persona hint |
-| `INWORLD_TTS_ENCODING` | `LINEAR16` | returned audio encoding |
-| `INWORLD_TTS_SAMPLE_RATE` | `48000` | sample rate used for WAV wrapping |
+Steering can improve expressiveness but adds a model call. Set `INWORLD_STEER=0` when time-to-first-audio is more important.
 
-Steering improves expressiveness but adds another model call before synthesis. Set `INWORLD_STEER=0` when time-to-first-audio is more important.
+HTTP 401/403 is treated as a credential error and stops immediately rather than silently changing voice.
 
-HTTP `401` and `403` are treated as credential/configuration failures. The Unix dispatcher intentionally exits loudly instead of silently switching to another voice.
+## Direct xAI TTS
 
-## xAI TTS
-
-xAI is an optional hosted engine and the final cloud fallback in several local-primary chains.
+The built-in Unix dispatcher can call xAI directly:
 
 ```bash
 export TTS_ENGINE=xai
-export XAI_API_KEY=...
+export XAI_API_KEY=replace-me
 export XAI_TTS_VOICE=eve
 ```
 
-The current script sends requests to the configured xAI TTS API path and supports the voice ids used by that provider integration. Hosted APIs can change; verify current provider access and schemas when diagnosing failures.
+This path sends text directly to xAI and does not run the shared AI Sentence Tagger provider validator. Use the companion bridge when exact shared tag/voice behavior is required.
 
 ## Speech-to-text providers
 
@@ -210,32 +271,26 @@ export STT_URL=http://127.0.0.1:5093/v1/audio/transcriptions
 export STT_MODEL=parakeet-tdt-0.6b-v3
 ```
 
-The request is multipart form data containing an audio file and model id.
-
 ### Remote OpenAI-compatible STT
-
-The Unix orchestrator supports a remote transcription endpoint:
 
 ```bash
 export STT_ENGINE=remote
 export STT_REMOTE_URL=https://api.openai.com/v1/audio/transcriptions
 export STT_REMOTE_MODEL=whisper-1
-export STT_API_KEY=...
+export STT_API_KEY=replace-me
 ```
 
-Credential precedence is:
+Credential precedence on Unix is:
 
 1. `STT_REMOTE_KEY`
 2. `STT_API_KEY`
 3. `OPENAI_API_KEY`
 
-No Authorization header is sent when the resolved key is empty, so an unauthenticated LAN endpoint can be used.
+No Authorization header is sent when the resolved key is empty, allowing unauthenticated private LAN endpoints.
 
-The Windows PowerShell orchestrator currently exposes the simpler `STT_URL` and `STT_MODEL` path. Do not assume every Unix remote-provider feature has PowerShell parity.
+## Built-in Unix fallback chains
 
-## Actual Unix fallback chains
-
-Fallback behavior is determined by `service/tts.sh`. The selected engine runs first.
+These apply only when `TTS_SH` is unset.
 
 | Selected `TTS_ENGINE` | Attempt order |
 |---|---|
@@ -245,24 +300,32 @@ Fallback behavior is determined by `service/tts.sh`. The selected engine runs fi
 | `neutts` | NeuTTS → Inflect Nano → Supertonic → xAI |
 | `inflect` | Inflect Nano → NeuTTS → Supertonic → xAI |
 | `openai` | OpenAI-compatible → Supertonic → NeuTTS |
-| `inworld` | Inworld → Qwen3-TTS → Supertonic → NeuTTS, except auth failures stop immediately |
+| `inworld` | Inworld → Qwen3-TTS → Supertonic → NeuTTS; auth failures stop |
 | `xai` | xAI → Supertonic → NeuTTS |
 
-Important implications:
+Implications:
 
-- A cloud provider is never contacted unless its engine is selected or it appears in that selected engine's chain and the preceding local attempts fail.
-- `XAI_API_KEY` can remain unset; the xAI attempt then fails and the dispatcher reports that all engines failed if no earlier engine succeeded.
-- `supertonic2` is not currently a valid dispatcher value.
-- The PowerShell path does not necessarily implement the same complete provider/fallback matrix.
+- Cloud providers are contacted only when selected or reached after preceding failures.
+- An unset `XAI_API_KEY` causes the xAI attempt to fail without exposing a credential.
+- `supertonic2` is not a dispatcher value.
+- The AI bridge is not a dispatcher value; it is a `TTS_SH` override.
+- Windows has a separate engine implementation and does not mirror every Unix path.
+
+## Chunked playback
+
+OpenAI-compatible, Inworld, and direct xAI paths can issue sentence requests concurrently while preserving playback order. `TTS_NO_PLAY=1` requires one file for pre-warmed listening or barge-in, so provider paths return or assemble one WAV.
+
+The companion bridge sends one utterance to `/api/process/json`; provider-specific direction and synthesis are handled there, and one validated WAV is returned.
 
 ## Privacy and security
 
 - Local VAD, Parakeet, and Supertonic keep microphone audio and reply text on the host.
 - Remote STT sends recorded audio to the selected endpoint.
 - Remote TTS sends reply text to the selected endpoint.
-- Inworld steering may send text through both the steering model path and the synthesis provider path.
-- Never commit credentials to `.env.example`, documentation, shell history, or issue reports.
-- Prefer scoped credentials and LAN TLS/authentication when exposing speech servers beyond localhost.
+- The AI bridge sends reply text to the companion; the companion may send directed text to xAI or Google.
+- Bind local services to loopback or a protected LAN.
+- Never commit provider credentials or include them in prompts, logs, screenshots, or issue reports.
+- Prefer scoped credentials and authenticated TLS when crossing host boundaries.
 
 ## Quick recipes
 
@@ -277,29 +340,21 @@ TTS_QUALITY=normal \
 talk.sh listen
 ```
 
-One-way local announcement:
+Google Gemini through the shared companion:
 
 ```bash
-TALK_AUTO_LISTEN=0 \
-TTS_ENGINE=supertonic \
-SUPERTONIC_URL=http://127.0.0.1:8766 \
-talk.sh speak "The task is complete."
+TTS_SH="$HOME/.config/opencode/ai-tts-provider/tts-provider.sh" \
+AI_TTS_URL=http://127.0.0.1:8000 \
+AI_TTS_PROVIDER=google \
+AI_TTS_VOICE=Kore \
+talk.sh speak "The release is ready."
 ```
 
-Use an OpenAI-compatible server on the LAN:
+OpenAI-compatible server on a LAN host:
 
 ```bash
 TTS_ENGINE=openai \
 OPENAI_TTS_URL=http://192.168.1.50:8000/v1 \
 OPENAI_TTS_KEY=local-token \
 talk.sh speak "Hello from the remote speech server."
-```
-
-Use the optional Supertonic 2 service:
-
-```bash
-TTS_ENGINE=supertonic \
-SUPERTONIC_URL=http://127.0.0.1:8880 \
-TTS_QUALITY=normal \
-talk.sh speak "Fast local synthesis."
 ```

--- a/integrations/ai-sentence-tagger/README.md
+++ b/integrations/ai-sentence-tagger/README.md
@@ -1,0 +1,188 @@
+# AI Sentence Tagger / AI Voice Studio bridge
+
+This integration lets the Unix Local VoiceMode orchestrator use the **same provider catalogs, direction validator, and synthesis clients** as:
+
+- [AI Sentence Tagger](https://github.com/groxaxo/xai-sentence-tagger)
+- [AI Voice Studio](https://github.com/groxaxo/xAI-Voice-Studio)
+
+The bridge does not duplicate xAI or Gemini tag logic. It calls a trusted companion service's stateless `POST /api/process/json` endpoint, which:
+
+1. tags the utterance with the selected provider grammar;
+2. validates exact source preservation;
+3. synthesizes the selected voice;
+4. returns canonical provider/voice metadata and base64 audio.
+
+The companion owns the local tagging model and cloud credentials. The Local VoiceMode process receives only the final WAV.
+
+## Supported contracts
+
+| Provider | Voices | Default voice | Direction model | Bridge WAV |
+|---|---:|---|---|---:|
+| xAI | 26 | `eve` | fixed 14 inline + 13 wrapping tags | 48 kHz |
+| Google Gemini | 30 | `Kore` | 16 common examples plus creative English direction | 24 kHz |
+
+`gemini` is accepted as an alias for `google`.
+
+Google's 16 examples are not an exhaustive allowlist. The companion service remains the source of truth for creative directions, lexical-boundary safeguards, canonical voice casing, and PCM-to-WAV handling.
+
+## 1. Start a companion service
+
+Use either repository.
+
+### AI Sentence Tagger
+
+```bash
+git clone https://github.com/groxaxo/xai-sentence-tagger.git
+cd xai-sentence-tagger
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -e .
+cp .env.example .env
+ai-tagger serve --host 127.0.0.1 --port 8000
+```
+
+### AI Voice Studio
+
+```bash
+git clone https://github.com/groxaxo/xAI-Voice-Studio.git
+cd xAI-Voice-Studio
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -e .
+cp .env.example .env
+ai-voice-studio serve --host 127.0.0.1 --port 8000
+```
+
+Configure the companion's OpenAI-compatible tagging model plus the provider keys it will use. Keep those credentials on the companion service.
+
+## 2. Install the bridge
+
+From Local VoiceMode LLM:
+
+```bash
+bash integrations/ai-sentence-tagger/install.sh
+```
+
+This installs:
+
+```text
+~/.config/opencode/ai-tts-provider/
+├── tts_provider.py
+└── tts-provider.sh
+```
+
+## 3. Route Local VoiceMode through it
+
+### Google Gemini
+
+```bash
+export TTS_SH="$HOME/.config/opencode/ai-tts-provider/tts-provider.sh"
+export AI_TTS_URL=http://127.0.0.1:8000
+export AI_TTS_PROVIDER=google
+export AI_TTS_VOICE=Kore
+export AI_TTS_LANGUAGE=auto
+
+~/.config/opencode/skills/talk/talk.sh speak "The deployment completed."
+```
+
+### xAI
+
+```bash
+export TTS_SH="$HOME/.config/opencode/ai-tts-provider/tts-provider.sh"
+export AI_TTS_URL=http://127.0.0.1:8000
+export AI_TTS_PROVIDER=xai
+export AI_TTS_VOICE=eve
+export AI_TTS_LANGUAGE=auto
+
+~/.config/opencode/skills/talk/talk.sh speak "The deployment completed."
+```
+
+`talk.sh` passes the detected source language to the bridge. `AI_TTS_LANGUAGE` overrides the synthesis language when set.
+
+## Catalog inspection
+
+```bash
+python3 ~/.config/opencode/ai-tts-provider/tts_provider.py providers
+python3 ~/.config/opencode/ai-tts-provider/tts_provider.py voices --provider xai
+python3 ~/.config/opencode/ai-tts-provider/tts_provider.py voices --provider google
+python3 ~/.config/opencode/ai-tts-provider/tts_provider.py tags --provider google
+python3 ~/.config/opencode/ai-tts-provider/tts_provider.py audio-formats --provider google
+python3 ~/.config/opencode/ai-tts-provider/tts_provider.py health
+```
+
+Catalog results come from the running companion, so they stay aligned with its tested contracts.
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `TTS_SH` | built-in `service/tts.sh` | Point to `tts-provider.sh` to select this integration |
+| `AI_TTS_URL` | `http://127.0.0.1:8000` | Companion service base URL |
+| `AI_TTS_PROVIDER` | `xai` | `xai`, `google`, or `gemini` |
+| `AI_TTS_VOICE` | provider default | Case-insensitive built-in voice ID |
+| `AI_TTS_SOURCE_LANGUAGE` | language passed by `talk.sh` | Override tagging language hint |
+| `AI_TTS_LANGUAGE` | source language | Synthesis language or `auto` |
+| `AI_TTS_COVERAGE` | `natural` | `natural`, `all`, or `all-per-sentence` |
+| `AI_TTS_STYLE_PROMPT` | unset | Gemini Director's Notes |
+| `AI_TTS_MODEL` | companion default | Gemini TTS model override |
+| `AI_TTS_TAGGER_MODEL` | companion default | Tagging-model override |
+| `AI_TTS_TAGGER_BASE_URL` | companion default | Tagging endpoint override |
+| `AI_TTS_TIMEOUT_SECONDS` | `180` | HTTP timeout |
+| `AI_TTS_MAX_AUDIO_BYTES` | `100000000` | Decoded-audio safety limit |
+| `AI_TTS_TOKEN` | unset | Optional bearer token for a protected companion |
+| `AI_TTS_PYTHON` | `python3` | Python used by the shell adapter |
+
+`AI_TTS_CODEC` must remain `wav`. `AI_TTS_SAMPLE_RATE` is an advanced override and must match a format accepted by the active provider.
+
+## VoiceMode contract
+
+The shell adapter implements the same interface expected from `service/tts.sh`:
+
+```text
+input:  text as argument 1, language hint as argument 2
+normal mode: synthesize and play
+TTS_NO_PLAY=1: print one WAV path to stdout
+diagnostics: stderr
+```
+
+This preserves pre-warmed listening and barge-in workflows.
+
+The bridge validates:
+
+- JSON response shape;
+- strict base64;
+- maximum decoded size;
+- `audio/wav` metadata;
+- RIFF/WAVE container signature;
+- atomic output-file replacement.
+
+## Routing and fallback implications
+
+Setting `TTS_SH` to this adapter **replaces** the built-in Unix dispatcher for that process. The normal Supertonic/Qwen/NeuTTS/xAI fallback graph is not entered automatically.
+
+To return to the local-first dispatcher:
+
+```bash
+unset TTS_SH
+export TTS_ENGINE=supertonic
+```
+
+For automatic failover between the companion and local engines, place your own wrapper in `TTS_SH` that calls this bridge first and `service/tts.sh` second.
+
+## Persistence
+
+The bridge uses `/api/process/json`, even when connected to AI Voice Studio. These utterances are stateless and do not create browser-visible Studio projects or jobs. Use the Studio browser or `/api/studio/*` endpoints when durable project history is required.
+
+## Security
+
+- Bind the companion to loopback or a protected private network.
+- Keep xAI, Google, and tagging-model credentials in the companion environment.
+- Use `AI_TTS_TOKEN` when a reverse proxy protects the companion with a bearer token.
+- The bridge sends reply text to the companion; the companion may then send directed text to the selected hosted speech provider.
+- Do not place credentials in `AI_TTS_STYLE_PROMPT`, agent prompts, shell history, or committed files.
+
+## Platform scope
+
+`tts-provider.sh` integrates directly with the Unix/macOS `talk.sh` path. The Python helper itself is cross-platform, but the Windows `talk.ps1` dispatcher is a separate implementation and is not automatically redirected by this installer.
+
+See [speech providers and fallback policy](../../docs/providers.md).

--- a/integrations/ai-sentence-tagger/install.sh
+++ b/integrations/ai-sentence-tagger/install.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_DIR="${AI_TTS_INSTALL_DIR:-$HOME/.config/opencode/ai-tts-provider}"
+
+mkdir -p "$TARGET_DIR"
+install -m 0755 "$SCRIPT_DIR/tts_provider.py" "$TARGET_DIR/tts_provider.py"
+install -m 0755 "$SCRIPT_DIR/tts-provider.sh" "$TARGET_DIR/tts-provider.sh"
+
+cat <<EOF
+Installed the AI Sentence Tagger / AI Voice Studio bridge:
+
+  $TARGET_DIR/tts-provider.sh
+
+Configure the companion service, then export:
+
+  export TTS_SH="$TARGET_DIR/tts-provider.sh"
+  export AI_TTS_URL="http://127.0.0.1:8000"
+  export AI_TTS_PROVIDER="google"   # or xai
+  export AI_TTS_VOICE="Kore"       # or eve for xAI
+
+Verify catalogs:
+
+  python3 "$TARGET_DIR/tts_provider.py" providers
+  python3 "$TARGET_DIR/tts_provider.py" voices --provider google
+EOF

--- a/integrations/ai-sentence-tagger/tts-provider.sh
+++ b/integrations/ai-sentence-tagger/tts-provider.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Local VoiceMode TTS_SH adapter for AI Sentence Tagger / AI Voice Studio.
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON="${AI_TTS_PYTHON:-python3}"
+TEXT="${1:-Hello.}"
+LANGUAGE="${2:-auto}"
+
+play_audio() {
+    local file="$1"
+    case "$(uname -s 2>/dev/null)" in
+        Darwin)
+            afplay "$file"
+            ;;
+        *)
+            if command -v ffplay >/dev/null 2>&1; then
+                ffplay -nodisp -autoexit -loglevel quiet "$file" 2>/dev/null
+            elif command -v aplay >/dev/null 2>&1; then
+                aplay -q "$file" 2>/dev/null
+            elif command -v paplay >/dev/null 2>&1; then
+                paplay "$file" 2>/dev/null
+            elif command -v mpv >/dev/null 2>&1; then
+                mpv --no-video --quiet "$file" 2>/dev/null
+            else
+                echo "ai-tts-provider: no supported audio player found" >&2
+                return 1
+            fi
+            ;;
+    esac
+}
+
+output_path="$(
+    "$PYTHON" "$SCRIPT_DIR/tts_provider.py" synthesize \
+        --text "$TEXT" \
+        --language "$LANGUAGE"
+)"
+
+if [ ! -s "$output_path" ]; then
+    echo "ai-tts-provider: synthesis returned no audio file" >&2
+    exit 1
+fi
+
+if [ "${TTS_NO_PLAY:-0}" = "1" ]; then
+    printf '%s\n' "$output_path"
+    exit 0
+fi
+
+trap 'rm -f "$output_path"' EXIT
+play_audio "$output_path"

--- a/integrations/ai-sentence-tagger/tts_provider.py
+++ b/integrations/ai-sentence-tagger/tts_provider.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Provider-aware Local VoiceMode bridge to AI Sentence Tagger / AI Voice Studio."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+DEFAULT_URL = "http://127.0.0.1:8000"
+DEFAULT_TIMEOUT_SECONDS = 180.0
+DEFAULT_MAX_AUDIO_BYTES = 100_000_000
+_PROVIDER_ALIASES = {
+    "xai": "xai",
+    "x-ai": "xai",
+    "grok": "xai",
+    "google": "google",
+    "google-ai": "google",
+    "googleai": "google",
+    "gemini": "google",
+}
+_COVERAGE_MODES = {"natural", "all", "all-per-sentence"}
+
+
+class BridgeError(RuntimeError):
+    """Safe, user-facing bridge failure."""
+
+
+def normalize_provider(value: str | None) -> str:
+    candidate = (value or "xai").strip().lower().replace("_", "-")
+    try:
+        return _PROVIDER_ALIASES[candidate]
+    except KeyError as exc:
+        raise BridgeError(
+            f"Unsupported AI_TTS_PROVIDER {value!r}; use xai, google, or gemini"
+        ) from exc
+
+
+def provider_output_format(provider: str) -> dict[str, Any]:
+    """Return a WAV format suitable for Local VoiceMode playback/barge-in."""
+    if normalize_provider(provider) == "google":
+        return {"codec": "wav", "sample_rate": 24000, "bit_rate": None}
+    return {"codec": "wav", "sample_rate": 48000, "bit_rate": None}
+
+
+def _env_text(name: str) -> str | None:
+    value = os.getenv(name)
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _positive_float(name: str, default: float) -> float:
+    raw = _env_text(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise BridgeError(f"{name} must be a number") from exc
+    if value <= 0:
+        raise BridgeError(f"{name} must be greater than zero")
+    return value
+
+
+def _positive_int(name: str, default: int) -> int:
+    raw = _env_text(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise BridgeError(f"{name} must be an integer") from exc
+    if value <= 0:
+        raise BridgeError(f"{name} must be greater than zero")
+    return value
+
+
+def build_process_payload(
+    text: str,
+    *,
+    provider: str,
+    source_language: str,
+) -> dict[str, Any]:
+    if not text.strip():
+        raise BridgeError("Refusing to synthesize blank text")
+
+    resolved = normalize_provider(provider)
+    coverage = (_env_text("AI_TTS_COVERAGE") or "natural").lower()
+    if coverage not in _COVERAGE_MODES:
+        choices = ", ".join(sorted(_COVERAGE_MODES))
+        raise BridgeError(f"AI_TTS_COVERAGE must be one of: {choices}")
+
+    output_format = provider_output_format(resolved)
+    codec = (_env_text("AI_TTS_CODEC") or output_format["codec"]).lower()
+    if codec != "wav":
+        raise BridgeError(
+            "Local VoiceMode's AI provider bridge requires WAV output; "
+            "set AI_TTS_CODEC=wav"
+        )
+    sample_rate_text = _env_text("AI_TTS_SAMPLE_RATE")
+    if sample_rate_text is not None:
+        try:
+            output_format["sample_rate"] = int(sample_rate_text)
+        except ValueError as exc:
+            raise BridgeError("AI_TTS_SAMPLE_RATE must be an integer") from exc
+    output_format["codec"] = "wav"
+    output_format["bit_rate"] = None
+
+    language = (_env_text("AI_TTS_SOURCE_LANGUAGE") or source_language or "auto").strip()
+    tts_language = _env_text("AI_TTS_LANGUAGE") or language or "auto"
+
+    payload: dict[str, Any] = {
+        "text": text,
+        "provider": resolved,
+        "language": language,
+        "coverage_mode": coverage,
+        "include_annotations": False,
+        "tts_language": tts_language,
+        "output_format": output_format,
+    }
+
+    optional = {
+        "voice_id": _env_text("AI_TTS_VOICE"),
+        "style_prompt": _env_text("AI_TTS_STYLE_PROMPT"),
+        "tts_model": _env_text("AI_TTS_MODEL"),
+        "model": _env_text("AI_TTS_TAGGER_MODEL"),
+        "base_url": _env_text("AI_TTS_TAGGER_BASE_URL"),
+    }
+    payload.update({key: value for key, value in optional.items() if value is not None})
+    return payload
+
+
+def _base_url() -> str:
+    return (_env_text("AI_TTS_URL") or DEFAULT_URL).rstrip("/")
+
+
+def _headers(*, json_body: bool = False) -> dict[str, str]:
+    headers = {"Accept": "application/json"}
+    if json_body:
+        headers["Content-Type"] = "application/json"
+    token = _env_text("AI_TTS_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def request_json(
+    path: str,
+    *,
+    method: str = "GET",
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    url = f"{_base_url()}/{path.lstrip('/')}"
+    body = None
+    if payload is not None:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    req = urllib_request.Request(
+        url,
+        data=body,
+        headers=_headers(json_body=payload is not None),
+        method=method,
+    )
+    timeout = _positive_float("AI_TTS_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS)
+
+    try:
+        with urllib_request.urlopen(req, timeout=timeout) as response:
+            raw = response.read()
+    except urllib_error.HTTPError as exc:
+        detail = exc.read(2000).decode("utf-8", errors="replace").strip()
+        raise BridgeError(
+            f"AI TTS service returned HTTP {exc.code}: {detail or exc.reason}"
+        ) from exc
+    except urllib_error.URLError as exc:
+        raise BridgeError(f"Cannot reach AI TTS service at {_base_url()}: {exc.reason}") from exc
+    except TimeoutError as exc:
+        raise BridgeError(f"AI TTS request timed out after {timeout:g} seconds") from exc
+
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise BridgeError("AI TTS service returned malformed JSON") from exc
+    if not isinstance(decoded, dict):
+        raise BridgeError("AI TTS service returned a non-object JSON response")
+    return decoded
+
+
+def decode_audio_response(payload: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:
+    encoded = payload.get("audio_base64")
+    if not isinstance(encoded, str) or not encoded:
+        raise BridgeError("AI TTS response is missing audio_base64")
+    try:
+        audio = base64.b64decode(encoded, validate=True)
+    except (ValueError, binascii.Error) as exc:
+        raise BridgeError("AI TTS response contains invalid base64 audio") from exc
+
+    limit = _positive_int("AI_TTS_MAX_AUDIO_BYTES", DEFAULT_MAX_AUDIO_BYTES)
+    if not audio:
+        raise BridgeError("AI TTS service returned empty audio")
+    if len(audio) > limit:
+        raise BridgeError(
+            f"AI TTS audio is {len(audio)} bytes, exceeding AI_TTS_MAX_AUDIO_BYTES={limit}"
+        )
+
+    extension = str(payload.get("audio_extension") or "").lower()
+    media_type = str(payload.get("media_type") or "").lower()
+    if extension != "wav" or media_type != "audio/wav":
+        raise BridgeError(
+            "AI TTS bridge requested WAV but the service returned "
+            f"{media_type or 'unknown media type'} / {extension or 'unknown extension'}"
+        )
+    if len(audio) < 12 or audio[:4] != b"RIFF" or audio[8:12] != b"WAVE":
+        raise BridgeError("AI TTS service returned an invalid WAV container")
+    return audio, payload
+
+
+def atomic_write(path: Path, content: bytes) -> Path:
+    target = path.expanduser().resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+        dir=target.parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, target)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+    return target
+
+
+def default_output_path() -> Path:
+    fd, name = tempfile.mkstemp(
+        prefix="local-voicemode-ai-",
+        suffix=".wav",
+        dir=os.getenv("TMPDIR") or "/tmp",
+    )
+    os.close(fd)
+    Path(name).unlink(missing_ok=True)
+    return Path(name)
+
+
+def synthesize(text: str, language: str, output: Path | None) -> tuple[Path, dict[str, Any]]:
+    provider = normalize_provider(_env_text("AI_TTS_PROVIDER") or "xai")
+    payload = build_process_payload(
+        text,
+        provider=provider,
+        source_language=language or "auto",
+    )
+    response = request_json("/api/process/json", method="POST", payload=payload)
+    audio, metadata = decode_audio_response(response)
+    target = atomic_write(output or default_output_path(), audio)
+    return target, metadata
+
+
+def print_catalog(kind: str, provider: str | None) -> None:
+    if kind == "providers":
+        payload = request_json("/api/providers")
+    elif kind == "health":
+        payload = request_json("/health")
+    else:
+        resolved = normalize_provider(provider or _env_text("AI_TTS_PROVIDER") or "xai")
+        payload = request_json(f"/api/{kind}?provider={resolved}")
+    print(json.dumps(payload, ensure_ascii=False, indent=2, default=str))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Bridge Local VoiceMode LLM to a local AI Sentence Tagger or AI Voice Studio "
+            "service for provider-correct xAI / Google Gemini speech."
+        )
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    synth = subparsers.add_parser("synthesize", help="Tag and synthesize one utterance")
+    synth.add_argument("--text", required=True)
+    synth.add_argument("--language", default="auto")
+    synth.add_argument("--output", type=Path)
+    synth.add_argument(
+        "--metadata",
+        action="store_true",
+        help="Write response metadata to stderr; stdout remains the audio path",
+    )
+
+    subparsers.add_parser("providers", help="Print provider catalog")
+    subparsers.add_parser("health", help="Print companion-service health")
+    for name in ("voices", "tags", "audio-formats"):
+        command = subparsers.add_parser(name, help=f"Print {name} catalog")
+        command.add_argument("--provider")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "synthesize":
+            path, metadata = synthesize(args.text, args.language, args.output)
+            if args.metadata:
+                safe = {
+                    key: metadata.get(key)
+                    for key in (
+                        "provider",
+                        "voice_id",
+                        "language",
+                        "output_format",
+                        "media_type",
+                        "audio_extension",
+                        "audio_bytes",
+                    )
+                }
+                print(json.dumps(safe, ensure_ascii=False, default=str), file=sys.stderr)
+            print(path)
+        elif args.command in {"providers", "health"}:
+            print_catalog(args.command, None)
+        else:
+            print_catalog(args.command, args.provider)
+    except BridgeError as exc:
+        print(f"ai-tts-provider: {exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        print("ai-tts-provider: interrupted", file=sys.stderr)
+        return 130
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -12,6 +12,16 @@ description: >-
 
 Use the installed Local VoiceMode LLM scripts. Never invent a transcript, claim audio was played without invoking the tool, or simulate microphone input.
 
+## Runtime paths
+
+| Role | Unix/macOS | Windows |
+|---|---|---|
+| Orchestrator | `~/.config/opencode/skills/talk/talk.sh` | `%USERPROFILE%\.config\opencode\skills\talk\talk.ps1` |
+| Recorder | `~/.config/opencode/skills/talk/vad_recorder.py` | skill-local `vad_recorder.py` |
+| Built-in TTS dispatcher | `~/.config/opencode/tts.sh` | provider logic in `talk.ps1` |
+| Language helper | `~/.config/opencode/tts_lang.sh` | orchestrator language argument |
+| Shared AI provider bridge | `~/.config/opencode/ai-tts-provider/tts-provider.sh` | Python helper is portable; automatic PowerShell routing is separate |
+
 Supported skill targets:
 
 | Agent | Skill path |
@@ -22,30 +32,18 @@ Supported skill targets:
 | Hermes Agent | `~/.hermes/skills/talk/` |
 | Codex | `~/.codex/skills/talk/` |
 
-## Runtime paths
-
-Use the script inside the active skill directory when possible. The canonical OpenCode installation is:
-
-| Role | Path |
-|---|---|
-| Unix orchestrator | `~/.config/opencode/skills/talk/talk.sh` |
-| Windows orchestrator | `%USERPROFILE%\.config\opencode\skills\talk\talk.ps1` |
-| Recorder | `~/.config/opencode/skills/talk/vad_recorder.py` |
-| TTS dispatcher | `~/.config/opencode/tts.sh` |
-| Language helper | `~/.config/opencode/tts_lang.sh` |
-
-Default managed local services:
+Default managed local endpoints:
 
 | Service | Endpoint |
 |---|---|
 | Parakeet STT | `http://127.0.0.1:5093/v1/audio/transcriptions` |
 | Supertonic 3 TTS | `http://127.0.0.1:8766` |
 
-The launching process should set `SUPERTONIC_URL=http://127.0.0.1:8766` explicitly so the dispatcher and installed service agree.
+The launching shell should set `SUPERTONIC_URL=http://127.0.0.1:8766` explicitly so the dispatcher and installed service agree.
 
 ## Commands
 
-Unix:
+Unix/macOS:
 
 ```bash
 ~/.config/opencode/skills/talk/talk.sh listen
@@ -76,27 +74,28 @@ transcript = talk.sh listen
 
 - Stdout is the user's transcribed utterance.
 - Diagnostics are written to stderr.
-- Empty stdout means no completed turn or a clean session end. Do not fabricate input.
+- Empty stdout means no completed turn or a clean session end.
+- Never fabricate input when stdout is empty.
 
 ### Subsequent turns
 
-After reasoning about the transcript, give a concise spoken reply and call `speak`:
+After reasoning about the transcript, produce a concise spoken reply and call `speak`:
 
 ```text
 next_transcript = talk.sh speak "assistant reply"
 ```
 
-With `TALK_AUTO_LISTEN=1`, `speak` performs all of the following:
+With `TALK_AUTO_LISTEN=1`, `speak`:
 
-1. Synthesize the assistant reply.
-2. Play it.
-3. Play the ready cue/beep.
-4. Open or activate the microphone.
-5. Record the next user turn.
-6. Transcribe it.
-7. Print the next transcript to stdout.
+1. synthesizes the assistant reply;
+2. plays it;
+3. plays the ready cue;
+4. activates the microphone;
+5. records the next user turn;
+6. transcribes it;
+7. prints the next transcript to stdout.
 
-Do **not** call `listen` after `speak`; doing so opens a second recording cycle and breaks the conversation protocol.
+Do **not** call `listen` after `speak`; doing so opens a second recording cycle.
 
 ### Loop
 
@@ -108,22 +107,18 @@ while transcript is non-empty:
 stop when stdout is empty
 ```
 
-Empty stdout from `speak` is the session-end signal. Exit cleanly and do not try to recover by listening again.
+Empty stdout from `speak` is the session-end signal. Exit cleanly instead of trying to recover with another listen call.
 
 ## Spoken-response style
 
-Voice responses should be easy to understand when heard once:
-
 - Lead with the answer or result.
 - Prefer short paragraphs and natural sentences.
-- Avoid reading long URLs, raw stack traces, tables, or large code blocks aloud.
-- Summarize technical detail and leave exact commands in the text response when appropriate.
+- Do not read long URLs, raw stack traces, large tables, or code blocks aloud.
+- Summarize technical detail and keep exact commands in the text response.
 - Ask only one spoken question at a time.
-- Do not narrate hidden reasoning or internal chain-of-thought.
+- Never narrate hidden reasoning or internal chain-of-thought.
 
 ## One-way read-aloud
-
-For a spoken notification without reopening the microphone:
 
 ```bash
 TALK_AUTO_LISTEN=0 \
@@ -133,21 +128,17 @@ talk.sh speak "The task completed successfully."
 
 ## Session termination
 
-A session can end through:
-
 | Signal | Behavior |
 |---|---|
-| Keyboard interruption | The running process is stopped |
-| Idle timeout | `listen` completes with empty stdout after `TALK_IDLE_TIMEOUT_S` |
-| Spoken stop phrase | A configured phrase in `TALK_STOP_PHRASES` produces empty stdout |
+| Keyboard interruption | running process stops |
+| Idle timeout | stdout is empty after `TALK_IDLE_TIMEOUT_S` |
+| Spoken stop phrase | matching `TALK_STOP_PHRASES` returns empty stdout |
 
-`TALK_STOP_PHRASES` is pipe-separated and uses case-insensitive substring matching. A safer explicit configuration is:
+Use specific stop phrases because matching is case-insensitive substring matching:
 
 ```bash
 export TALK_STOP_PHRASES="end voice mode|stop the conversation|para de hablar"
 ```
-
-Because matching is permissive, avoid very short stop phrases that are likely to appear in normal speech.
 
 ## Recommended local environment
 
@@ -163,60 +154,99 @@ export VAD_MIN_SILENCE_MS=700
 export TALK_IDLE_TIMEOUT_S=300
 ```
 
-The scripts do not automatically source the repository `.env.example`.
+The scripts do not automatically source `.env.example`.
+
+## TTS routing
+
+### Built-in Unix dispatcher
+
+When `TTS_SH` is unset, `TTS_ENGINE` selects the primary implementation in `service/tts.sh`:
+
+```text
+supertonic, qwen, qwen-lazy, neutts, inflect, openai, inworld, xai
+```
+
+Supertonic 2 has no separate alias; point the compatible Supertonic client at `:8880`.
+
+### Shared xAI / Google Gemini bridge
+
+For provider-correct sentence direction and the shared 26/30-voice catalogs, install:
+
+```bash
+bash integrations/ai-sentence-tagger/install.sh
+```
+
+Then select Google:
+
+```bash
+export TTS_SH="$HOME/.config/opencode/ai-tts-provider/tts-provider.sh"
+export AI_TTS_URL=http://127.0.0.1:8000
+export AI_TTS_PROVIDER=google
+export AI_TTS_VOICE=Kore
+export AI_TTS_LANGUAGE=auto
+```
+
+Or xAI:
+
+```bash
+export TTS_SH="$HOME/.config/opencode/ai-tts-provider/tts-provider.sh"
+export AI_TTS_URL=http://127.0.0.1:8000
+export AI_TTS_PROVIDER=xai
+export AI_TTS_VOICE=eve
+```
+
+The bridge calls a local AI Sentence Tagger or AI Voice Studio companion. The companion owns the local tagging model and provider credentials.
+
+Important rules:
+
+- `TTS_SH` is an implementation override, not a `TTS_ENGINE` value.
+- Setting it bypasses the built-in fallback graph.
+- Unset `TTS_SH` to restore local-first `TTS_ENGINE` routing.
+- The bridge uses stateless `/api/process/json`; it does not create persistent Studio projects.
+- Google has 30 canonical voices and creative English directions; its 16 common examples are non-exhaustive.
+- xAI has 26 canonical built-in voices and a fixed 27-tag grammar.
+- The adapter forces WAV and preserves the `TTS_NO_PLAY=1` single-file contract used by pre-warmed listening and barge-in.
 
 ## Important environment variables
 
 | Variable | Purpose |
 |---|---|
 | `STT_ENGINE` | Unix STT routing: `local` or `remote` |
-| `STT_URL` | Local transcription endpoint |
-| `STT_MODEL` | Local model id |
-| `STT_REMOTE_URL` | Unix remote transcription endpoint |
-| `STT_REMOTE_MODEL` | Unix remote model id |
-| `STT_API_KEY` | Optional remote STT bearer token |
-| `TTS_ENGINE` | Unix primary TTS dispatcher value |
-| `SUPERTONIC_URL` | Supertonic-compatible endpoint; managed default is `:8766` |
-| `SUPERTONIC_VOICE` | Supertonic voice id, `F1`–`F5` or `M1`–`M5` |
-| `TTS_QUALITY` | `normal` for 8 steps or `high` for 20 steps |
-| `TTS_FADE_MS` | Edge fade in milliseconds |
-| `VAD_THRESHOLD` | Speech sensitivity |
-| `VAD_MIN_SILENCE_MS` | Silence required to close a turn |
-| `MIC_QUERY` | Input-device name substring |
-| `TALK_AUTO_LISTEN` | Listen after playback |
-| `TALK_BARGE_IN` | Interrupt playback on detected speech |
-| `TALK_IDLE_TIMEOUT_S` | End an idle session after N seconds; `0` disables |
-| `TALK_STOP_PHRASES` | Pipe-separated spoken stop phrases |
+| `STT_URL` / `STT_MODEL` | local transcription endpoint and model |
+| `STT_REMOTE_URL` / `STT_API_KEY` | remote transcription |
+| `TTS_ENGINE` | built-in primary TTS engine |
+| `TTS_SH` | Unix TTS implementation override |
+| `SUPERTONIC_URL` / `SUPERTONIC_VOICE` | local Supertonic service and voice |
+| `TTS_QUALITY` | `normal` for 8 steps or `high` for 20 |
+| `AI_TTS_URL` | AI Sentence Tagger / Voice Studio companion URL |
+| `AI_TTS_PROVIDER` | `xai`, `google`, or `gemini` |
+| `AI_TTS_VOICE` | provider voice ID |
+| `AI_TTS_STYLE_PROMPT` | Gemini Director's Notes |
+| `VAD_THRESHOLD` | speech sensitivity |
+| `VAD_MIN_SILENCE_MS` | silence needed to close a turn |
+| `MIC_QUERY` | input-device name substring |
+| `TALK_AUTO_LISTEN` | listen after playback |
+| `TALK_BARGE_IN` | interrupt playback on detected speech |
+| `TALK_IDLE_TIMEOUT_S` | end an idle session; `0` disables |
+| `TALK_STOP_PHRASES` | pipe-separated spoken stop phrases |
 
-Unix `TTS_ENGINE` values implemented by the current dispatcher:
-
-```text
-supertonic, qwen, qwen-lazy, neutts, inflect, openai, inworld, xai
-```
-
-The optional Supertonic 2 service has no dedicated alias today. Select it through the compatible client:
-
-```bash
-TTS_ENGINE=supertonic SUPERTONIC_URL=http://127.0.0.1:8880 talk.sh speak "Hello"
-```
-
-Do not assume that every Unix provider feature is implemented by the Windows PowerShell orchestrator.
+Do not assume that every Unix provider feature exists in the Windows PowerShell orchestrator. Windows supports its own Supertonic, direct xAI, and IndexTTS paths; the companion Python helper is portable, but this installer does not automatically rewrite PowerShell routing.
 
 ## Barge-in
 
-`TALK_BARGE_IN=1` starts VAD during playback and stops audio when speech is detected. Enable it only when the microphone does not strongly capture the speakers.
-
-It is not acoustic echo cancellation. With speaker bleed, the assistant's own voice can trigger an interruption. Prefer headphones or leave barge-in disabled.
+`TALK_BARGE_IN=1` starts VAD during playback and stops audio when speech is detected. It is not acoustic echo cancellation. Speaker bleed can interrupt the assistant's own voice; prefer headphones or leave it disabled.
 
 ## Troubleshooting rules
 
 1. Run `status` after installation or service restart.
 2. Run `devices` and select the microphone explicitly when capture is uncertain.
 3. Force the managed TTS endpoint with `SUPERTONIC_URL=http://127.0.0.1:8766`.
-4. For missed speech, lower `VAD_THRESHOLD`; for background triggers, raise it.
-5. For premature turn endings, raise `VAD_MIN_SILENCE_MS`.
-6. If all TTS engines fail, report the backend error; do not substitute system TTS and claim the configured voice played.
-7. Never expose API keys in logs, messages, or commands that will be committed.
-8. Respect empty stdout as a deliberate session-end signal.
+4. Inspect `TTS_SH` before diagnosing `TTS_ENGINE`; an override bypasses the dispatcher.
+5. For the AI bridge, run its `health`, `providers`, and `voices` catalog commands before synthesis.
+6. For missed speech, lower `VAD_THRESHOLD`; for background triggers, raise it.
+7. For premature turn endings, raise `VAD_MIN_SILENCE_MS`.
+8. If all TTS paths fail, report the actual backend error; never substitute system TTS and claim the configured voice played.
+9. Never expose API keys in logs, messages, screenshots, or committed commands.
+10. Respect empty stdout as a deliberate session-end signal.
 
-Full operator guidance is in `docs/troubleshooting.md` in the Local VoiceMode LLM repository.
+Full operator guidance is in `docs/troubleshooting.md`, `docs/providers.md`, and `docs/ai-provider-bridge.md`.

--- a/tests/test_ai_tts_provider.py
+++ b/tests/test_ai_tts_provider.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "integrations"
+    / "ai-sentence-tagger"
+    / "tts_provider.py"
+)
+SPEC = importlib.util.spec_from_file_location("ai_tts_provider", MODULE_PATH)
+assert SPEC and SPEC.loader
+provider = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(provider)
+
+
+def wav_bytes() -> bytes:
+    return (
+        b"RIFF"
+        + (36).to_bytes(4, "little")
+        + b"WAVE"
+        + b"fmt "
+        + (16).to_bytes(4, "little")
+        + (1).to_bytes(2, "little")
+        + (1).to_bytes(2, "little")
+        + (24000).to_bytes(4, "little")
+        + (48000).to_bytes(4, "little")
+        + (2).to_bytes(2, "little")
+        + (16).to_bytes(2, "little")
+        + b"data"
+        + (0).to_bytes(4, "little")
+    )
+
+
+class FakeResponse:
+    def __init__(self, payload: dict):
+        self.payload = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return None
+
+    def read(self):
+        return self.payload
+
+
+class ProviderBridgeTests(unittest.TestCase):
+    def test_provider_aliases(self):
+        self.assertEqual(provider.normalize_provider("gemini"), "google")
+        self.assertEqual(provider.normalize_provider("GROK"), "xai")
+        with self.assertRaises(provider.BridgeError):
+            provider.normalize_provider("unknown")
+
+    def test_google_payload_uses_provider_native_wav(self):
+        with patch.dict(os.environ, {}, clear=True):
+            payload = provider.build_process_payload(
+                "Hello.", provider="gemini", source_language="en"
+            )
+        self.assertEqual(payload["provider"], "google")
+        self.assertEqual(
+            payload["output_format"],
+            {"codec": "wav", "sample_rate": 24000, "bit_rate": None},
+        )
+        self.assertEqual(payload["coverage_mode"], "natural")
+        self.assertEqual(payload["tts_language"], "en")
+
+    def test_xai_payload_uses_wav_for_voicemode(self):
+        with patch.dict(
+            os.environ,
+            {
+                "AI_TTS_VOICE": "EVE",
+                "AI_TTS_LANGUAGE": "auto",
+                "AI_TTS_STYLE_PROMPT": "Ignored by xAI transport",
+            },
+            clear=True,
+        ):
+            payload = provider.build_process_payload(
+                "Hello.", provider="xai", source_language="en"
+            )
+        self.assertEqual(payload["provider"], "xai")
+        self.assertEqual(payload["voice_id"], "EVE")
+        self.assertEqual(payload["output_format"]["sample_rate"], 48000)
+        self.assertEqual(payload["output_format"]["codec"], "wav")
+
+    def test_rejects_non_wav_override(self):
+        with patch.dict(os.environ, {"AI_TTS_CODEC": "mp3"}, clear=True):
+            with self.assertRaisesRegex(provider.BridgeError, "requires WAV"):
+                provider.build_process_payload(
+                    "Hello.", provider="xai", source_language="en"
+                )
+
+    def test_strict_audio_decode(self):
+        audio = wav_bytes()
+        decoded, metadata = provider.decode_audio_response(
+            {
+                "audio_base64": base64.b64encode(audio).decode(),
+                "audio_extension": "wav",
+                "media_type": "audio/wav",
+            }
+        )
+        self.assertEqual(decoded, audio)
+        self.assertEqual(metadata["audio_extension"], "wav")
+        with self.assertRaisesRegex(provider.BridgeError, "invalid base64"):
+            provider.decode_audio_response(
+                {
+                    "audio_base64": "%%%",
+                    "audio_extension": "wav",
+                    "media_type": "audio/wav",
+                }
+            )
+
+    def test_atomic_write(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "speech.wav"
+            result = provider.atomic_write(target, wav_bytes())
+            self.assertEqual(result, target.resolve())
+            self.assertEqual(target.read_bytes(), wav_bytes())
+            self.assertFalse(list(target.parent.glob(".speech.wav.*.tmp")))
+
+    def test_request_json_uses_companion_api_and_token(self):
+        captured = {}
+
+        def fake_urlopen(req, timeout):
+            captured["url"] = req.full_url
+            captured["timeout"] = timeout
+            captured["authorization"] = req.headers.get("Authorization")
+            captured["body"] = json.loads(req.data)
+            return FakeResponse({"ok": True})
+
+        with patch.dict(
+            os.environ,
+            {
+                "AI_TTS_URL": "http://127.0.0.1:9000/",
+                "AI_TTS_TOKEN": "secret-token",
+                "AI_TTS_TIMEOUT_SECONDS": "9",
+            },
+            clear=True,
+        ), patch.object(provider.urllib_request, "urlopen", fake_urlopen):
+            result = provider.request_json(
+                "/api/process/json",
+                method="POST",
+                payload={"provider": "google"},
+            )
+
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(captured["url"], "http://127.0.0.1:9000/api/process/json")
+        self.assertEqual(captured["timeout"], 9.0)
+        self.assertEqual(captured["authorization"], "Bearer secret-token")
+        self.assertEqual(captured["body"]["provider"], "google")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a standard-library `TTS_SH` bridge to a local AI Sentence Tagger or AI Voice Studio companion
- reuse the companion's verified 26-voice xAI and 30-voice Gemini catalogs instead of duplicating provider logic
- preserve provider-correct direction, exact source validation, canonical voice IDs, and Google PCM-to-WAV handling
- force one validated WAV for VoiceMode playback, pre-warmed listening, and barge-in
- add strict JSON/base64/RIFF validation, bounded audio size, optional bearer authentication, and atomic file writes
- document bridge installation, routing, security boundaries, environment variables, fallback implications, and platform scope
- refresh the root README, provider reference, docs index, and agent skill

## Staged commits

1. `feat: add shared AI TTS provider bridge`
2. `docs: document xAI and Gemini companion bridge`
3. `docs: align agent and architecture guidance`
4. `test: make bridge unittest directly runnable`

## Validation

No GitHub Actions were used as a release gate.

- exact published Python and shell blobs match the locally validated files byte-for-byte
- `python -m py_compile` passed
- seven deterministic unit tests passed through discovery and direct module execution
- `bash -n` passed for the adapter and installer
- branch is ahead of `main` with no divergence
- remote tree confirms executable modes, documentation, integration files, and tests
- relative documentation links were checked against the exact remote tree

## Boundary

The bridge integrates directly with Unix/macOS `talk.sh` through `TTS_SH`. The Python client is portable, but the Windows PowerShell dispatcher remains a separate implementation and is not silently claimed as integrated.

Provider credentials remain in the local companion service; none are added to this repository.