### PR TITLE
feat: require sentence tags before every xAI request

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,7 @@
 #
 # The companion service owns the local tagging model and xAI/Google credentials.
 # Local VoiceMode calls its /api/process/json endpoint and receives a validated WAV.
+# The bridge requires proof that every segmented sentence received a valid tag.
 # Install with: bash integrations/ai-sentence-tagger/install.sh
 #
 # TTS_SH=$HOME/.config/opencode/ai-tts-provider/tts-provider.sh
@@ -62,7 +63,7 @@
 # AI_TTS_CODEC=wav                    # required by the VoiceMode bridge
 # AI_TTS_SAMPLE_RATE=24000            # advanced; must be provider-supported
 #
-# TTS_SH replaces the built-in Unix dispatcher for that process. Unset TTS_SH to
+# TTS_SH replaces the built-in Unix wrapper for that process. Unset TTS_SH to
 # restore TTS_ENGINE routing and the normal local-first fallback graph.
 
 # =============================================================================
@@ -123,7 +124,7 @@
 # OPENAI_TTS_KEY=local-token
 
 # =============================================================================
-# Optional hosted providers through the built-in Unix dispatcher
+# Optional hosted providers through the built-in Unix wrapper
 # =============================================================================
 
 # Inworld expressive TTS
@@ -136,11 +137,23 @@
 # INWORLD_TTS_ENCODING=LINEAR16
 # INWORLD_TTS_SAMPLE_RATE=48000
 
-# Direct xAI TTS (no local sentence-tagger bridge)
+# Direct xAI TTS with mandatory sentence-by-sentence tagging.
+# No xAI request is sent until every sentence has at least one valid xAI tag.
 # TTS_ENGINE=xai
 # XAI_API_KEY=replace-me
+# XAI_TTS_URL=https://api.x.ai/v1/tts
 # XAI_TTS_VOICE=eve
 # XAI_TTS_MODEL=grok-2-audio
+# TTS_TAG_MODE=auto                   # auto | llm | deterministic
+# TTS_TAGGER_URL=http://127.0.0.1:12434/v1
+# TTS_TAGGER_MODEL=your-local-model
+# TTS_TAGGER_API_KEY=not-needed
+# TTS_TAGGER_TEMPERATURE=0.2
+# TTS_TAGGER_TIMEOUT_SECONDS=30
+# XAI_TTS_TIMEOUT_SECONDS=60
+#
+# auto: use the OpenAI-compatible model when configured, then deterministically
+# repair any missing/invalid sentence. deterministic: make no LLM request.
 
 # =============================================================================
 # Optional Ollama voice integration

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ This directory contains the operational and technical reference for Local VoiceM
 | [Apple Silicon MLX setup and repair](macos-repair.md) | Installing, validating, benchmarking, or forcing MLX/ONNX on a Mac |
 | [Troubleshooting](troubleshooting.md) | A microphone, backend, playback path, provider, or service is not working |
 | [Providers](providers.md) | Choosing local/remote STT or TTS, credentials, and fallback behavior |
+| [Mandatory xAI sentence tagging](xai-sentence-tagging.md) | Configuring or auditing the one-valid-tag-per-sentence xAI invariant |
 | [Shared AI provider bridge](ai-provider-bridge.md) | Reusing AI Sentence Tagger / AI Voice Studio for verified xAI and Gemini voices |
 | [Architecture](architecture.md) | Reviewing runtime design, data flow, boundaries, ports, and platform differences |
 | [Agent skill contract](../skill/SKILL.md) | Integrating the voice loop into Claude Code, OpenCode, OpenClaw, Hermes, or Codex |
@@ -34,11 +35,15 @@ Silero VAD ──► WAV ──► Parakeet STT :5093
                          talk orchestrator
                          │             │
                          ▼             ▼
-                   built-in tts.sh   optional TTS_SH bridge
-                         │             │
-                         └──────┬──────┘
-                                ▼
-                          audio playback
+                  service/tts.sh     optional TTS_SH bridge
+                  safety wrapper             │
+                    │       │                 │
+                    ▼       ▼                 │
+            tts_backends  tagged xAI         │
+                    │       │                 │
+                    └───────┴────────┬────────┘
+                                    ▼
+                              audio playback
 ```
 
 Default local services:
@@ -53,12 +58,15 @@ Default local services:
 
 ## Routing concepts
 
-The documentation distinguishes four layers:
+The documentation distinguishes five layers:
 
 1. **Backend service** — the STT/TTS server and port.
-2. **Built-in dispatcher** — `service/tts.sh`, selected through `TTS_ENGINE` on Unix.
-3. **Implementation override** — `TTS_SH`, used by the shared AI provider bridge.
-4. **Agent orchestrator/skill** — `talk.sh`, `talk.ps1`, and the instructions an agent follows.
+2. **Safety wrapper** — `service/tts.sh`; owns every direct or fallback xAI request and enforces sentence tags.
+3. **Backend dispatcher** — `service/tts_backends.sh`; implements Supertonic, Qwen, NeuTTS, Inflect, OpenAI-compatible, Inworld, and the historical engine orders.
+4. **Implementation override** — `TTS_SH`, used by the shared AI provider bridge.
+5. **Agent orchestrator/skill** — `talk.sh`, `talk.ps1`, and the instructions an agent follows.
+
+`TTS_ENGINE` selects the requested backend through the wrapper. The wrapper clears `XAI_API_KEY` while running `tts_backends.sh`, so raw text cannot reach its historical xAI fallback. A legitimate xAI attempt returns to `service/tts.sh`, where every sentence is tagged and audited first.
 
 A healthy backend does not prove that the orchestrator is using the same endpoint. Always inspect the effective environment of the process that launches the agent.
 
@@ -74,10 +82,23 @@ export VAD_THRESHOLD=0.5
 export VAD_MIN_SILENCE_MS=700
 ```
 
+For direct xAI with a local tagging model:
+
+```bash
+export TTS_ENGINE=xai
+export XAI_API_KEY=replace-me
+export TTS_TAG_MODE=auto
+export TTS_TAGGER_URL=http://127.0.0.1:12434/v1
+export TTS_TAGGER_MODEL=your-local-model
+export TTS_TAGGER_API_KEY=not-needed
+```
+
 The repository includes [`.env.example`](../.env.example) as a reference. Shell scripts do not automatically source arbitrary `.env` files.
 
 ## Support boundary
 
 The core supported path is local Silero VAD, local Parakeet STT, local Supertonic TTS, and the platform-native orchestrator on macOS, Linux, or Windows.
+
+The strict direct-xAI wrapper is implemented on Unix/macOS. The companion bridge also integrates directly with Unix/macOS `talk.sh`. Windows uses a separate PowerShell dispatcher and is not silently claimed to share those Unix routing changes.
 
 Optional providers and integrations are secondary paths. Their authentication, schemas, latency, and availability can change independently. The AI provider bridge avoids duplicating xAI/Gemini contracts by reading catalogs and synthesizing through a versioned companion service.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -8,23 +8,27 @@ Local VoiceMode LLM is designed around a local speech path:
 
 Remote providers and companion services are optional. Use them when a specific hosted voice is required, a slow machine needs offload, or provider-correct sentence direction adds value.
 
-## Two TTS routing mechanisms
+## Unix TTS routing layers
 
-The Unix orchestrator supports two distinct routing layers.
+### 1. Safety wrapper: `service/tts.sh`
 
-### 1. Built-in dispatcher
+When `TTS_SH` is unset, `talk.sh` invokes `service/tts.sh`. The wrapper interprets `TTS_ENGINE`, delegates ordinary engines to `service/tts_backends.sh`, and owns every direct or fallback xAI request.
 
-When `TTS_SH` is unset, `talk.sh` runs `service/tts.sh`. `TTS_ENGINE` chooses the primary engine and its explicit fallback chain.
+The wrapper will not send an xAI request until every segmented sentence has at least one valid xAI speech tag. It also clears `XAI_API_KEY` while the historical dispatcher runs, so the old raw-xAI fallback cannot be reached.
 
-### 2. Implementation override
+### 2. Backend dispatcher: `service/tts_backends.sh`
 
-When `TTS_SH` points to another executable, `talk.sh` invokes that implementation instead. The AI Sentence Tagger / AI Voice Studio bridge uses this mechanism.
+This contains the existing Supertonic, Qwen, NeuTTS, Inflect Nano, OpenAI-compatible, Inworld, and legacy xAI implementation functions. The safety wrapper invokes it with xAI credentials intentionally hidden. A normal backend failure returns to the wrapper, which may perform a separately validated xAI fallback.
+
+### 3. Implementation override: `TTS_SH`
+
+When `TTS_SH` points to another executable, `talk.sh` invokes that implementation instead. The AI Sentence Tagger / AI Voice Studio bridge uses this mechanism:
 
 ```bash
 export TTS_SH="$HOME/.config/opencode/ai-tts-provider/tts-provider.sh"
 ```
 
-An override bypasses the built-in dispatcher; `TTS_ENGINE` fallback does not run automatically.
+An override bypasses the built-in wrapper and dispatcher. The bridge therefore performs its own mandatory per-sentence proof before accepting audio.
 
 ## Recommended local baseline
 
@@ -48,15 +52,13 @@ The scripts inherit environment variables from their launcher. They do not autom
 | Apple Silicon with separate service | local Parakeet | Qwen3-TTS or Supertonic MLX |
 | Old or heavily loaded CPU | local first | remote OpenAI-compatible TTS |
 | Air-gapped or privacy-sensitive | local only | local only |
-| Expressive hosted voice | local Parakeet | Inworld, xAI, or companion bridge |
-| Verified xAI/Gemini catalogs and sentence direction | local Parakeet | AI Sentence Tagger / Voice Studio bridge |
+| Expressive hosted voice | local Parakeet | Inworld or sentence-tagged xAI |
+| Verified xAI/Gemini catalogs | local Parakeet | AI Sentence Tagger / Voice Studio bridge |
 | Speech service on a LAN host | configurable URL | OpenAI-compatible or bridge URL |
 
 ## Local TTS engines
 
 ### Supertonic 3
-
-Default installed backend:
 
 ```bash
 export TTS_ENGINE=supertonic
@@ -76,8 +78,6 @@ export TTS_QUALITY=normal
 
 ### Supertonic 2
 
-The optional service uses an OpenAI-compatible endpoint on `:8880`:
-
 ```bash
 bash integrations/supertonic2/install.sh
 TTS_ENGINE=supertonic \
@@ -85,7 +85,7 @@ SUPERTONIC_URL=http://127.0.0.1:8880 \
 talk.sh speak "Hello from Supertonic 2"
 ```
 
-There is no dedicated `supertonic2` dispatcher value; the URL chooses the compatible service.
+There is no dedicated `supertonic2` value; the compatible endpoint is selected by URL.
 
 ### NeuTTS
 
@@ -103,7 +103,7 @@ export TTS_ENGINE=inflect
 export INFLECT_URL=http://127.0.0.1:8030
 ```
 
-Inflect is experimental and English-only. It declines other languages so the fallback chain can continue.
+Inflect is experimental and English-only. It declines other languages so fallback can continue.
 
 ### Qwen3-TTS
 
@@ -119,7 +119,7 @@ export QWEN_TTS_VOICE=vivian
 | `hq` | `http://127.0.0.1:18882` |
 | `lazy` | `http://127.0.0.1:18883` |
 
-Set `QWEN_TTS_URL` to bypass quality-based URL selection.
+Set `QWEN_TTS_URL` to bypass quality-based selection.
 
 ### Windows IndexTTS
 
@@ -132,20 +132,71 @@ $env:INDEXTTS_REF_AUDIO = "C:\voices\reference.wav"
 .\windows\talk.ps1 speak "Hello"
 ```
 
-A valid reference WAV is required. This path is implemented by `windows/talk.ps1`, not the Unix shell dispatcher.
+A valid reference WAV is required. This path is implemented by `windows/talk.ps1`, not the Unix wrapper.
+
+## Direct xAI TTS: mandatory sentence tagging
+
+```bash
+export TTS_ENGINE=xai
+export XAI_API_KEY=replace-me
+export XAI_TTS_VOICE=eve
+export TTS_TAG_MODE=auto
+```
+
+All direct and fallback xAI requests pass through `service/xai_sentence_tagger.py` first. The helper:
+
+1. segments the exact source into indexed sentences;
+2. optionally asks an OpenAI-compatible model for context-aware xAI tags;
+3. rejects missing, duplicate, unknown-tag, unbalanced, or source-rewriting rows;
+4. deterministically repairs every invalid or omitted sentence;
+5. reports `tagged_sentence_count == sentence_count`; and
+6. fails before the provider request if any sentence remains untagged.
+
+The fixed xAI grammar is 14 inline tags plus 13 wrapping tags.
+
+### Tag modes
+
+| `TTS_TAG_MODE` | Behavior |
+|---|---|
+| `auto` | Use a configured local model, then deterministically repair every invalid or missing sentence |
+| `llm` | Prefer the configured model, with the same mandatory deterministic repair |
+| `deterministic` | Make no tagging-model request; use validated local rules only |
+
+### OpenAI-compatible local tagger
+
+```bash
+export TTS_TAGGER_URL=http://127.0.0.1:12434/v1
+export TTS_TAGGER_MODEL=your-local-model
+export TTS_TAGGER_API_KEY=not-needed
+export TTS_TAGGER_TEMPERATURE=0.2
+export TTS_TAGGER_TIMEOUT_SECONDS=30
+```
+
+Inspect the result without synthesizing:
+
+```bash
+printf '%s' 'Hello. Are you there?' | \
+  python3 service/xai_sentence_tagger.py \
+    --mode deterministic --language en --format json | python3 -m json.tool
+```
+
+See [Mandatory xAI sentence tagging](xai-sentence-tagging.md).
 
 ## Shared AI Sentence Tagger / AI Voice Studio bridge
 
 The optional bridge reuses a local companion service as the source of truth for xAI and Google Gemini voices, sentence direction, validation, and synthesis.
-
-Supported contracts:
 
 | Provider | Built-in voices | Default voice | Direction semantics | VoiceMode output |
 |---|---:|---|---|---|
 | xAI | 26 | `eve` | fixed 14 inline + 13 wrapping tags | WAV 48 kHz |
 | Google Gemini | 30 | `Kore` | 16 common examples plus creative English direction | WAV 24 kHz |
 
-Google's 16 examples are non-exhaustive. The companion enforces exact source preservation, literal bracket-cue handling, lexical boundaries, canonical voice casing, and PCM-to-WAV conversion.
+The bridge requests `include_annotations=true` and refuses audio unless the companion proves:
+
+- one annotation per source sentence;
+- `tagged_sentence_count == sentence_count`;
+- no untagged indexes; and
+- inserted provider direction in every annotation.
 
 ### Install
 
@@ -153,7 +204,7 @@ Google's 16 examples are non-exhaustive. The companion enforces exact source pre
 bash integrations/ai-sentence-tagger/install.sh
 ```
 
-### Select Google
+### Google
 
 ```bash
 export TTS_SH="$HOME/.config/opencode/ai-tts-provider/tts-provider.sh"
@@ -163,7 +214,7 @@ export AI_TTS_VOICE=Kore
 export AI_TTS_LANGUAGE=auto
 ```
 
-### Select xAI
+### xAI
 
 ```bash
 export TTS_SH="$HOME/.config/opencode/ai-tts-provider/tts-provider.sh"
@@ -172,12 +223,7 @@ export AI_TTS_PROVIDER=xai
 export AI_TTS_VOICE=eve
 ```
 
-The companion can be either:
-
-- `groxaxo/xai-sentence-tagger`; or
-- `groxaxo/xAI-Voice-Studio`.
-
-Both expose the required stateless `/api/process/json` endpoint. The bridge does not create persistent Studio projects.
+The companion can be either `groxaxo/xai-sentence-tagger` or `groxaxo/xAI-Voice-Studio`. Both expose `/api/process/json`; the bridge remains stateless and does not create persistent Studio projects.
 
 ### Bridge variables
 
@@ -190,14 +236,14 @@ Both expose the required stateless `/api/process/json` endpoint. The bridge does
 | `AI_TTS_LANGUAGE` | source language | Synthesis language |
 | `AI_TTS_COVERAGE` | `natural` | Direction coverage mode |
 | `AI_TTS_STYLE_PROMPT` | unset | Gemini Director's Notes |
-| `AI_TTS_MODEL` | companion default | Gemini TTS model override |
+| `AI_TTS_MODEL` | companion default | TTS model override |
 | `AI_TTS_TAGGER_MODEL` | companion default | Tagging-model override |
 | `AI_TTS_TAGGER_BASE_URL` | companion default | Tagging endpoint override |
 | `AI_TTS_TOKEN` | unset | Optional bearer token |
 | `AI_TTS_TIMEOUT_SECONDS` | `180` | Request timeout |
 | `AI_TTS_MAX_AUDIO_BYTES` | `100000000` | Decoded-audio limit |
 
-The bridge forces WAV because pre-warmed listening and barge-in expect a single playable file. `AI_TTS_SAMPLE_RATE` is an advanced override and must be supported by the active provider.
+The bridge forces WAV because pre-warmed listening and barge-in expect one playable file.
 
 ### Catalog inspection
 
@@ -207,22 +253,16 @@ python3 ~/.config/opencode/ai-tts-provider/tts_provider.py voices --provider goo
 python3 ~/.config/opencode/ai-tts-provider/tts_provider.py tags --provider google
 ```
 
-### Restore local-first routing
+Restore the built-in local-first path with:
 
 ```bash
 unset TTS_SH
 export TTS_ENGINE=supertonic
 ```
 
-See [the complete integration guide](../integrations/ai-sentence-tagger/README.md).
+See [the complete bridge guide](../integrations/ai-sentence-tagger/README.md).
 
 ## Remote OpenAI-compatible TTS
-
-The `openai` engine sends the standard speech payload to:
-
-```text
-<OPENAI_TTS_URL>/audio/speech
-```
 
 ```bash
 export TTS_ENGINE=openai
@@ -233,7 +273,7 @@ export OPENAI_TTS_VOICE=alloy
 export OPENAI_TTS_FORMAT=wav
 ```
 
-`OPENAI_API_KEY` is used when `OPENAI_TTS_KEY` is unset. Compatibility is not guaranteed solely because a server advertises an OpenAI-like API; verify fields and returned audio.
+The engine sends the standard speech payload to `<OPENAI_TTS_URL>/audio/speech`. `OPENAI_API_KEY` is used when `OPENAI_TTS_KEY` is unset.
 
 ## Inworld TTS
 
@@ -245,21 +285,7 @@ export INWORLD_TTS_MODEL=inworld-tts-2
 export INWORLD_STEER=auto
 ```
 
-Steering can improve expressiveness but adds a model call. Set `INWORLD_STEER=0` when time-to-first-audio is more important.
-
-HTTP 401/403 is treated as a credential error and stops immediately rather than silently changing voice.
-
-## Direct xAI TTS
-
-The built-in Unix dispatcher can call xAI directly:
-
-```bash
-export TTS_ENGINE=xai
-export XAI_API_KEY=replace-me
-export XAI_TTS_VOICE=eve
-```
-
-This path sends text directly to xAI and does not run the shared AI Sentence Tagger provider validator. Use the companion bridge when exact shared tag/voice behavior is required.
+HTTP 401/403 remains terminal. The safety wrapper preserves exit status 3 and does not hide credential refusal behind an xAI fallback.
 
 ## Speech-to-text providers
 
@@ -280,81 +306,37 @@ export STT_REMOTE_MODEL=whisper-1
 export STT_API_KEY=replace-me
 ```
 
-Credential precedence on Unix is:
+Credential precedence on Unix is `STT_REMOTE_KEY`, then `STT_API_KEY`, then `OPENAI_API_KEY`. No Authorization header is sent when the resolved key is empty.
 
-1. `STT_REMOTE_KEY`
-2. `STT_API_KEY`
-3. `OPENAI_API_KEY`
+## Effective Unix fallback chains
 
-No Authorization header is sent when the resolved key is empty, allowing unauthenticated private LAN endpoints.
+These apply only when `TTS_SH` is unset. `tagged xAI` always means the hard per-sentence audit passed first.
 
-## Built-in Unix fallback chains
-
-These apply only when `TTS_SH` is unset.
-
-| Selected `TTS_ENGINE` | Attempt order |
+| Selected `TTS_ENGINE` | Effective attempt order |
 |---|---|
-| `supertonic` | Supertonic → NeuTTS → xAI |
-| `qwen` | Qwen3-TTS → Supertonic → NeuTTS → xAI |
-| `qwen-lazy` | Qwen lazy → Supertonic → NeuTTS → xAI |
-| `neutts` | NeuTTS → Inflect Nano → Supertonic → xAI |
-| `inflect` | Inflect Nano → NeuTTS → Supertonic → xAI |
-| `openai` | OpenAI-compatible → Supertonic → NeuTTS |
-| `inworld` | Inworld → Qwen3-TTS → Supertonic → NeuTTS; auth failures stop |
-| `xai` | xAI → Supertonic → NeuTTS |
+| `supertonic` | Supertonic → NeuTTS → tagged xAI |
+| `qwen` | Qwen3-TTS → Supertonic → NeuTTS → tagged xAI |
+| `qwen-lazy` | Qwen lazy → Supertonic → NeuTTS → tagged xAI |
+| `neutts` | NeuTTS → Inflect Nano → Supertonic → tagged xAI |
+| `inflect` | Inflect Nano → NeuTTS → Supertonic → tagged xAI |
+| `openai` | OpenAI-compatible → Supertonic → NeuTTS → tagged xAI |
+| `inworld` | Inworld → Qwen3-TTS → Supertonic → NeuTTS → tagged xAI on non-auth failure |
+| `xai` | tagged xAI → Supertonic → NeuTTS |
 
-Implications:
+Unknown engines retain exit status 2. Explicit credential refusals retain exit status 3. Neither falls back to xAI.
 
-- Cloud providers are contacted only when selected or reached after preceding failures.
-- An unset `XAI_API_KEY` causes the xAI attempt to fail without exposing a credential.
-- `supertonic2` is not a dispatcher value.
-- The AI bridge is not a dispatcher value; it is a `TTS_SH` override.
-- Windows has a separate engine implementation and does not mirror every Unix path.
+## Chunking and playback
 
-## Chunked playback
+OpenAI-compatible and Inworld implementations can issue sentence requests concurrently while preserving playback order. Direct xAI intentionally sends the fully directed document only after the complete sentence invariant has been checked.
 
-OpenAI-compatible, Inworld, and direct xAI paths can issue sentence requests concurrently while preserving playback order. `TTS_NO_PLAY=1` requires one file for pre-warmed listening or barge-in, so provider paths return or assemble one WAV.
-
-The companion bridge sends one utterance to `/api/process/json`; provider-specific direction and synthesis are handled there, and one validated WAV is returned.
+`TTS_NO_PLAY=1` requires one file for pre-warmed listening or barge-in, so every successful path returns or assembles one WAV.
 
 ## Privacy and security
 
-- Local VAD, Parakeet, and Supertonic keep microphone audio and reply text on the host.
+- Local VAD, Parakeet, Supertonic, and deterministic tag repair keep data on the host.
+- A configured local tagging endpoint receives reply text.
 - Remote STT sends recorded audio to the selected endpoint.
-- Remote TTS sends reply text to the selected endpoint.
-- The AI bridge sends reply text to the companion; the companion may send directed text to xAI or Google.
+- Remote TTS sends directed reply text to the selected provider.
+- The companion bridge sends reply text to the companion, which may contact xAI or Google.
 - Bind local services to loopback or a protected LAN.
 - Never commit provider credentials or include them in prompts, logs, screenshots, or issue reports.
-- Prefer scoped credentials and authenticated TLS when crossing host boundaries.
-
-## Quick recipes
-
-Local low-latency conversation:
-
-```bash
-STT_ENGINE=local \
-STT_URL=http://127.0.0.1:5093/v1/audio/transcriptions \
-TTS_ENGINE=supertonic \
-SUPERTONIC_URL=http://127.0.0.1:8766 \
-TTS_QUALITY=normal \
-talk.sh listen
-```
-
-Google Gemini through the shared companion:
-
-```bash
-TTS_SH="$HOME/.config/opencode/ai-tts-provider/tts-provider.sh" \
-AI_TTS_URL=http://127.0.0.1:8000 \
-AI_TTS_PROVIDER=google \
-AI_TTS_VOICE=Kore \
-talk.sh speak "The release is ready."
-```
-
-OpenAI-compatible server on a LAN host:
-
-```bash
-TTS_ENGINE=openai \
-OPENAI_TTS_URL=http://192.168.1.50:8000/v1 \
-OPENAI_TTS_KEY=local-token \
-talk.sh speak "Hello from the remote speech server."
-```

--- a/docs/xai-sentence-tagging.md
+++ b/docs/xai-sentence-tagging.md
@@ -1,0 +1,162 @@
+# Mandatory xAI sentence tagging
+
+Every xAI synthesis request made by the Unix Local VoiceMode runtime now carries at least one valid xAI speech tag for every segmented sentence.
+
+This is a hard pre-audio invariant, not a prompt preference.
+
+## Request path
+
+```text
+reply text
+   │
+   ▼
+service/tts.sh                         safety wrapper
+   │
+   ├─ non-xAI engine ─► service/tts_backends.sh
+   │                         │
+   │                         └─ failure ───────────┐
+   │                                               │
+   └─ xAI selected ────────────────────────────────┤
+                                                   ▼
+                                service/xai_sentence_tagger.py
+                                                   │
+                                                   ├─ segment every sentence
+                                                   ├─ optional local LLM direction
+                                                   ├─ exact source validation
+                                                   ├─ deterministic repair
+                                                   └─ assert N/N sentences tagged
+                                                   │
+                                                   ▼
+                                          POST xAI /v1/tts
+```
+
+The historical engine implementations remain in `service/tts_backends.sh`. The wrapper clears `XAI_API_KEY` while running that dispatcher, which makes its legacy raw-xAI fallback unreachable. If the selected/local backends fail, control returns to the wrapper and the final xAI attempt passes through the same sentence tagger.
+
+## Invariant
+
+The helper emits structured proof:
+
+```json
+{
+  "provider": "xai",
+  "sentence_count": 3,
+  "tagged_sentence_count": 3,
+  "untagged_sentence_indexes": [],
+  "tagged_text": "...",
+  "sentences": [
+    {
+      "index": 0,
+      "original": "Hello.",
+      "tagged_text": "<emphasis>Hello.</emphasis>",
+      "tags": ["emphasis"],
+      "source": "deterministic"
+    }
+  ]
+}
+```
+
+`service/tts.sh` independently checks the counts, indexes, inserted-tag lists, and reconstructed tagged text before building the xAI request. If the proof is incomplete, no provider request is made.
+
+## Tag modes
+
+### `auto`
+
+```bash
+export TTS_TAG_MODE=auto
+```
+
+Uses the configured OpenAI-compatible model when available. Each model row is validated independently. Missing, malformed, unknown-tag, unbalanced, or source-rewriting output is replaced deterministically.
+
+### `llm`
+
+```bash
+export TTS_TAG_MODE=llm
+```
+
+Attempts the configured model first and still applies deterministic sentence repair. It therefore retains the same 100% invariant when the model omits or corrupts one sentence.
+
+### `deterministic`
+
+```bash
+export TTS_TAG_MODE=deterministic
+```
+
+Makes no tagging-model request. Contextual punctuation and keyword rules choose from the fixed xAI grammar, with a deterministic cycle for neutral sentences.
+
+## Local LLM configuration
+
+```bash
+export TTS_TAGGER_URL=http://127.0.0.1:12434/v1
+export TTS_TAGGER_MODEL=your-local-model
+export TTS_TAGGER_API_KEY=not-needed
+export TTS_TAGGER_TEMPERATURE=0.2
+export TTS_TAGGER_TIMEOUT_SECONDS=30
+```
+
+`TTS_TAGGER_URL` accepts either an OpenAI-compatible base URL, a `/v1` URL, or the complete `/chat/completions` URL.
+
+The model receives the exact fixed xAI grammar:
+
+- 14 inline tags
+- 13 wrapping tags
+- one output row per indexed source sentence
+- no source rewriting
+
+## Direct use
+
+Inspect the tagging result without synthesizing:
+
+```bash
+printf '%s' 'Hello. Are you there?' | \
+  python3 service/xai_sentence_tagger.py \
+    --mode deterministic \
+    --language en \
+    --format json | python3 -m json.tool
+```
+
+Synthesize through xAI:
+
+```bash
+export TTS_ENGINE=xai
+export XAI_API_KEY=replace-me
+export XAI_TTS_VOICE=eve
+export TTS_TAG_MODE=auto
+
+TTS_NO_PLAY=1 bash service/tts.sh \
+  'Hello. Are you there?' en
+```
+
+`TTS_NO_PLAY=1` prints the generated WAV path. The same path is used by pre-warmed listening and barge-in.
+
+## Companion-service bridge
+
+The optional AI Sentence Tagger / AI Voice Studio bridge has an independent form of the same rule. It requests `include_annotations=true` from `/api/process/json` and refuses returned audio unless:
+
+- `tagged_sentence_count == sentence_count`;
+- `untagged_sentence_indexes` is empty;
+- there is one unique annotation per sentence; and
+- every annotation differs from its original source sentence.
+
+This means both available xAI paths—the built-in Unix wrapper and the companion bridge—fail before playback when a sentence lacks direction.
+
+## Fallback semantics
+
+For non-xAI engines, the existing local/remote order still runs first. Only after a normal backend failure may the wrapper use sentence-tagged xAI.
+
+Terminal dispatcher errors remain terminal:
+
+- unknown `TTS_ENGINE` exits with status 2;
+- explicit credential refusals such as Inworld HTTP 401/403 exit with status 3;
+- neither is hidden by an xAI fallback.
+
+## Validation
+
+```bash
+python -m py_compile service/xai_sentence_tagger.py
+bash -n service/tts.sh service/tts_backends.sh
+python -m unittest tests.test_xai_sentence_tagger -v
+python -m unittest tests.test_tts_wrapper -v
+python -m unittest tests.test_ai_tts_provider -v
+```
+
+The deterministic tests inspect the exact xAI JSON payload and verify that every source sentence is represented by valid, source-preserving tagged text before the fake provider is called.

--- a/integrations/ai-sentence-tagger/tts_provider.py
+++ b/integrations/ai-sentence-tagger/tts_provider.py
@@ -45,7 +45,6 @@ def normalize_provider(value: str | None) -> str:
 
 
 def provider_output_format(provider: str) -> dict[str, Any]:
-    """Return a WAV format suitable for Local VoiceMode playback/barge-in."""
     if normalize_provider(provider) == "google":
         return {"codec": "wav", "sample_rate": 24000, "bit_rate": None}
     return {"codec": "wav", "sample_rate": 48000, "bit_rate": None}
@@ -124,7 +123,7 @@ def build_process_payload(
         "provider": resolved,
         "language": language,
         "coverage_mode": coverage,
-        "include_annotations": False,
+        "include_annotations": True,
         "tts_language": tts_language,
         "output_format": output_format,
     }
@@ -194,6 +193,51 @@ def request_json(
     return decoded
 
 
+def validate_sentence_tagging_response(payload: dict[str, Any]) -> dict[str, int]:
+    """Reject audio unless the companion proves every sentence received a tag."""
+    tagging = payload.get("tagging")
+    if not isinstance(tagging, dict):
+        raise BridgeError("AI TTS response is missing tagging metadata")
+
+    sentence_count = tagging.get("sentence_count")
+    tagged_count = tagging.get("tagged_sentence_count")
+    untagged = tagging.get("untagged_sentence_indexes")
+    annotations = tagging.get("annotations")
+    if not isinstance(sentence_count, int) or sentence_count < 1:
+        raise BridgeError("AI TTS response has an invalid sentence_count")
+    if tagged_count != sentence_count:
+        raise BridgeError(
+            "AI TTS sentence-tag invariant failed: "
+            f"{tagged_count!r}/{sentence_count} sentences are tagged"
+        )
+    if untagged != []:
+        raise BridgeError(f"AI TTS response contains untagged sentence indexes: {untagged!r}")
+    if not isinstance(annotations, list) or len(annotations) != sentence_count:
+        raise BridgeError("AI TTS response is missing complete per-sentence annotations")
+
+    seen: set[int] = set()
+    for row in annotations:
+        if not isinstance(row, dict):
+            raise BridgeError("AI TTS response contains a malformed sentence annotation")
+        index = row.get("index")
+        original = row.get("original")
+        tagged_text = row.get("tagged_text")
+        if not isinstance(index, int) or index < 0 or index >= sentence_count or index in seen:
+            raise BridgeError("AI TTS response contains missing or duplicate sentence indexes")
+        if not isinstance(original, str) or not isinstance(tagged_text, str):
+            raise BridgeError(f"AI TTS sentence {index} has malformed text fields")
+        if tagged_text == original:
+            raise BridgeError(f"AI TTS sentence {index} has no inserted speech tag")
+        seen.add(index)
+    if seen != set(range(sentence_count)):
+        raise BridgeError("AI TTS response omitted one or more sentence annotations")
+
+    return {
+        "sentence_count": sentence_count,
+        "tagged_sentence_count": tagged_count,
+    }
+
+
 def decode_audio_response(payload: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:
     encoded = payload.get("audio_base64")
     if not isinstance(encoded, str) or not encoded:
@@ -257,13 +301,15 @@ def default_output_path() -> Path:
 
 def synthesize(text: str, language: str, output: Path | None) -> tuple[Path, dict[str, Any]]:
     provider = normalize_provider(_env_text("AI_TTS_PROVIDER") or "xai")
-    payload = build_process_payload(
+    request_payload = build_process_payload(
         text,
         provider=provider,
         source_language=language or "auto",
     )
-    response = request_json("/api/process/json", method="POST", payload=payload)
+    response = request_json("/api/process/json", method="POST", payload=request_payload)
+    invariant = validate_sentence_tagging_response(response)
     audio, metadata = decode_audio_response(response)
+    metadata["sentence_tagging"] = invariant
     target = atomic_write(output or default_output_path(), audio)
     return target, metadata
 
@@ -323,6 +369,7 @@ def main(argv: list[str] | None = None) -> int:
                         "media_type",
                         "audio_extension",
                         "audio_bytes",
+                        "sentence_tagging",
                     )
                 }
                 print(json.dumps(safe, ensure_ascii=False, default=str), file=sys.stderr)

--- a/scripts/install.d/90-install.sh
+++ b/scripts/install.d/90-install.sh
@@ -22,25 +22,37 @@ install_supertonic
 
 info "── Installing voice skill files ──"
 mkdir -p "$SKILL_DIR"
-for file in vad_recorder.py talk.sh tts.sh tts_lang.sh doctor.sh; do
+for file in \
+  vad_recorder.py \
+  talk.sh \
+  tts.sh \
+  tts_backends.sh \
+  xai_sentence_tagger.py \
+  tts_lang.sh \
+  doctor.sh; do
   [[ -f "$REPO_DIR/service/$file" ]] && cp "$REPO_DIR/service/$file" "$SKILL_DIR/$file"
 done
 [[ -f "$REPO_DIR/skill/SKILL.md" ]] && cp "$REPO_DIR/skill/SKILL.md" "$SKILL_DIR/SKILL.md"
-chmod +x "$SKILL_DIR"/*.sh "$SKILL_DIR"/vad_recorder.py 2>/dev/null || true
-# The source still supports legacy Chatterbox on :8765. Installed Supertonic
-# clients must point to this installer's selected Supertonic port instead.
-sed -E -i.bak "s#SUPERTONIC_URL:=http://127\\.0\\.0\\.1:[0-9]+#SUPERTONIC_URL:=http://127.0.0.1:${SUPERTONIC_PORT}#" "$SKILL_DIR/tts.sh"
-rm -f "$SKILL_DIR/tts.sh.bak"
-cp "$SKILL_DIR/tts.sh" "$CONFIG_DIR/tts.sh"
-cp "$REPO_DIR/service/tts_lang.sh" "$CONFIG_DIR/tts_lang.sh"
-chmod +x "$CONFIG_DIR/tts.sh" "$CONFIG_DIR/tts_lang.sh"
+chmod +x "$SKILL_DIR"/*.sh "$SKILL_DIR"/vad_recorder.py "$SKILL_DIR"/xai_sentence_tagger.py 2>/dev/null || true
+# The backend source still supports legacy Chatterbox on :8765. Installed
+# Supertonic clients must point to this installer's selected Supertonic port.
+sed -E -i.bak "s#SUPERTONIC_URL:=http://127\\.0\\.0\\.1:[0-9]+#SUPERTONIC_URL:=http://127.0.0.1:${SUPERTONIC_PORT}#" "$SKILL_DIR/tts_backends.sh"
+rm -f "$SKILL_DIR/tts_backends.sh.bak"
+for file in tts.sh tts_backends.sh xai_sentence_tagger.py tts_lang.sh; do
+  cp "$SKILL_DIR/$file" "$CONFIG_DIR/$file"
+done
+chmod +x \
+  "$CONFIG_DIR/tts.sh" \
+  "$CONFIG_DIR/tts_backends.sh" \
+  "$CONFIG_DIR/xai_sentence_tagger.py" \
+  "$CONFIG_DIR/tts_lang.sh"
 
 install_integration() {
   local name="$1" target="$2" enabled="$3"
   [[ "$enabled" == true ]] || return 0
   if [[ "$target" == "$SKILL_DIR" ]]; then ok "Integration ready: $name → $target"; return 0; fi
   mkdir -p "$target"; cp -R "$SKILL_DIR/." "$target/"
-  chmod +x "$target"/*.sh "$target"/vad_recorder.py 2>/dev/null || true
+  chmod +x "$target"/*.sh "$target"/vad_recorder.py "$target"/xai_sentence_tagger.py 2>/dev/null || true
   ok "Integration ready: $name → $target"
 }
 install_integration "Claude Code" "$HOME/.claude/skills/talk" "$INTEGRATE_CLAUDECODE"

--- a/service/tts.sh
+++ b/service/tts.sh
@@ -168,14 +168,22 @@ case "$ENGINE" in
         run_backends_without_xai supertonic
         ;;
     *)
+        backend_status=0
         if run_backends_without_xai "$ENGINE"; then
             exit 0
+        else
+            backend_status=$?
         fi
+        # Preserve terminal dispatcher semantics: unknown engines (2) and explicit
+        # credential refusals such as Inworld 401/403 (3) must not be masked.
+        case "$backend_status" in
+            2|3) exit "$backend_status" ;;
+        esac
         if [ -n "$XAI_KEY" ]; then
             echo "[tts] Local/selected backends failed → trying sentence-tagged xAI…" >&2
             speak_xai_tagged
         else
-            exit 1
+            exit "$backend_status"
         fi
         ;;
 esac

--- a/service/tts.sh
+++ b/service/tts.sh
@@ -1,1052 +1,181 @@
-#!/bin/bash
-# tts.sh — Multi-engine TTS CLI for OpenCode / talk skill.
+#!/usr/bin/env bash
+# Provider-safe TTS entry point.
 #
-# Local engines:  supertonic (repo default) · qwen (MLX) · neutts
-# Remote engines (for slow CPUs): openai (any OpenAI-compatible /v1/audio/speech),
-#                  inworld (expressive, per-sentence steering), xai (last resort).
-# Set TTS_ENGINE to override. With a LOCAL primary, the local engines are always
-# tried before any cloud. Choosing a remote engine (openai/inworld/xai) honors that
-# choice first, then still falls back to local. macOS `say` is intentionally not used.
-#
-# Slow CPU? Point TTS_ENGINE=openai at any OpenAI-compatible endpoint (OpenAI, a
-# hosted provider, or your own remote box) to offload synthesis. See docs/providers.md.
+# The historical multi-backend dispatcher now lives in tts_backends.sh. This
+# wrapper owns every xAI request so raw, untagged text can never reach xAI TTS.
+# Before synthesis it runs xai_sentence_tagger.py, verifies a one-tag-per-sentence
+# invariant, and only then submits the directed text. Other engines keep their
+# existing behavior; if they fail, the final xAI fallback is also tagged here.
 
 set -e
 
-# Cross-platform WAV playback (macOS afplay, Linux ffplay/aplay/paplay)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_SH="${TTS_BACKEND_SH:-$SCRIPT_DIR/tts_backends.sh}"
+TAGGER_PY="${TTS_SENTENCE_TAGGER_PY:-$SCRIPT_DIR/xai_sentence_tagger.py}"
+TEXT="${1:-Hello.}"
+LANG="${2:-auto}"
+ENGINE="$(printf '%s' "${TTS_ENGINE:-supertonic}" | tr '[:upper:]' '[:lower:]')"
+XAI_KEY="${XAI_API_KEY:-}"
+XAI_URL="${XAI_TTS_URL:-https://api.x.ai/v1/tts}"
+XAI_VOICE="$(printf '%s' "${XAI_TTS_VOICE:-eve}" | tr '[:upper:]' '[:lower:]')"
+TAG_MODE="${TTS_TAG_MODE:-auto}"
+: "${TTS_NO_PLAY:=0}"
+
 play_wav() {
-    local f="$1"
-    [ -f "$f" ] || return 1
+    local file="$1"
+    [ -f "$file" ] || return 1
     case "$(uname -s 2>/dev/null)" in
-        Darwin) afplay "$f" ;;
+        Darwin) afplay "$file" ;;
         *)
-            if command -v ffplay &>/dev/null; then
-                ffplay -nodisp -autoexit -loglevel quiet "$f" 2>/dev/null
-            elif command -v aplay &>/dev/null; then
-                aplay -q "$f" 2>/dev/null
-            elif command -v paplay &>/dev/null; then
-                paplay "$f" 2>/dev/null
+            if command -v ffplay >/dev/null 2>&1; then
+                ffplay -nodisp -autoexit -loglevel quiet "$file" 2>/dev/null
+            elif command -v aplay >/dev/null 2>&1; then
+                aplay -q "$file" 2>/dev/null
+            elif command -v paplay >/dev/null 2>&1; then
+                paplay "$file" 2>/dev/null
+            elif command -v cvlc >/dev/null 2>&1; then
+                cvlc --play-and-exit --no-video "$file" 2>/dev/null
+            elif command -v mpv >/dev/null 2>&1; then
+                mpv --no-video --quiet "$file" 2>/dev/null
             else
-                echo "[tts] No audio player found (install ffmpeg)" >&2; return 1
+                echo "[tts] No audio player found (install ffmpeg for ffplay)" >&2
+                return 1
             fi ;;
     esac
 }
 
-# Apply a short fade-in/out to a WAV in place to kill onset/offset clicks.
-# Inworld (and some neural TTS) clips start on a non-zero sample — the first
-# sample jumps straight to ~60-99% of peak, an audible pop at the start of
-# every chunk/phrase. A few ms of fade ramps that to zero. Idempotent and
-# cheap; safe to call on any mono/stereo 8/16/32-bit PCM WAV.
-: "${TTS_FADE_MS:=6}"
-fade_wav_edges() {
-    local f="$1" ms="${2:-${TTS_FADE_MS:-6}}"
-    [ -f "$f" ] || return 1
-    [ "$ms" = "0" ] && return 0
-    python3 - "$f" "$ms" <<'PY' 2>/dev/null || return 0
-import wave, struct, sys
-path, ms = sys.argv[1], float(sys.argv[2])
-try:
-    with wave.open(path, 'rb') as w:
-        params = w.getparams()
-        frames = w.readframes(w.getnframes())
-except Exception:
-    sys.exit(0)
-sw = params.sampwidth
-fmt = {1:'b', 2:'h', 4:'i'}.get(sw)
-if fmt is None:
-    sys.exit(0)
-n = len(frames) // sw
-samples = list(struct.unpack(f'<{n}{fmt}', frames))
-ch = max(1, params.nchannels)
-fade_n = int(params.framerate * ms / 1000.0) * ch   # ramp length in samples
-if fade_n > 0 and n > fade_n * 2:
-    for i in range(fade_n):
-        g = i / fade_n
-        samples[i] = int(samples[i] * g)
-        samples[-(i+1)] = int(samples[-(i+1)] * g)
-    with wave.open(path, 'wb') as w:
-        w.setparams(params)
-        w.writeframes(struct.pack(f'<{n}{fmt}', *samples))
+run_backends_without_xai() {
+    local requested_engine="$1"
+    if [ ! -x "$BACKEND_SH" ]; then
+        echo "tts.sh: backend dispatcher is missing or not executable: $BACKEND_SH" >&2
+        return 1
+    fi
+    # The old dispatcher contains a raw xAI fallback. Clear the key so every xAI
+    # request is forced back through this wrapper and its sentence-tag invariant.
+    XAI_API_KEY= TTS_ENGINE="$requested_engine" bash "$BACKEND_SH" "$TEXT" "$LANG"
+}
+
+build_xai_request() {
+    local report_file="$1"
+    local request_file="$2"
+    python3 - "$report_file" "$request_file" "$XAI_VOICE" "$LANG" <<'PY'
+import json
+import sys
+
+report_path, request_path, voice, language = sys.argv[1:]
+with open(report_path, encoding="utf-8") as handle:
+    report = json.load(handle)
+
+sentences = report.get("sentences")
+sentence_count = report.get("sentence_count")
+tagged_count = report.get("tagged_sentence_count")
+untagged = report.get("untagged_sentence_indexes")
+if not isinstance(sentence_count, int) or sentence_count < 1:
+    raise SystemExit("sentence tagger returned an invalid sentence_count")
+if tagged_count != sentence_count or untagged != []:
+    raise SystemExit(
+        f"sentence tag invariant failed: {tagged_count}/{sentence_count}; untagged={untagged}"
+    )
+if not isinstance(sentences, list) or len(sentences) != sentence_count:
+    raise SystemExit("sentence tagger returned an incomplete sentence list")
+for expected, row in enumerate(sentences):
+    if not isinstance(row, dict) or row.get("index") != expected:
+        raise SystemExit("sentence tagger returned missing, duplicate, or unordered indexes")
+    if not row.get("tags") or row.get("tagged_text") == row.get("original"):
+        raise SystemExit(f"sentence {expected} has no inserted xAI tag")
+
+tagged_text = report.get("tagged_text")
+if not isinstance(tagged_text, str) or not tagged_text:
+    raise SystemExit("sentence tagger returned no tagged_text")
+
+payload = {
+    "text": tagged_text,
+    "voice_id": voice,
+    "language": language or "auto",
+    "output_format": {"codec": "wav", "sample_rate": 48000},
+}
+with open(request_path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, ensure_ascii=False)
+print(f"{tagged_count}/{sentence_count}")
 PY
 }
 
-# --- Engine config -----------------------------------------------------------
-# Default engine is `supertonic` (zero-setup, on-device, no API key). The other
-# engines are OPTIONAL — opt in with TTS_ENGINE=<name>:
-#   qwen      — local MLX Qwen3-TTS server (Apple Silicon). Setup/server:
-#               https://github.com/groxaxo/Qwen3-TTS-Openai-Fastapi
-#   neutts    — local NeuTTS GGUF server
-#   inworld   — Inworld AI cloud (needs INWORLD_API_KEY / INWORLD_TTS_API)
-#   xai       — xAI Grok cloud (needs XAI_API_KEY); last-resort fallback
-: "${TTS_ENGINE:=supertonic}"
-# Qwen3-TTS — local MLX server (Apple Silicon), OpenAI-compatible
-# /v1/audio/speech. Native voices: serena, vivian, uncle_fu, ryan, aiden,
-# ono_anna, sohee, eric, dylan (OpenAI aliases alloy/nova/… also accepted).
-# The model auto-detects language, so no lang_code is sent. WAV keeps latency
-# low (no mp3/pydub encode step).
-# Server + setup: https://github.com/groxaxo/Qwen3-TTS-Openai-Fastapi
-#
-# Three CustomVoice MLX servers (see the Qwen3-TTS repo above):
-#   fast → 0.6B on :18881 (low latency)     hq → 1.7B on :18882 (always-on)
-#   lazy → 1.7B on :18883 (auto-start, 5-min idle timeout, frees VRAM when idle)
-# QWEN_TTS_QUALITY=fast|hq|lazy picks which. An explicit QWEN_TTS_URL overrides.
-: "${QWEN_TTS_URL_FAST:=http://127.0.0.1:18881}"
-: "${QWEN_TTS_URL_HQ:=http://127.0.0.1:18882}"
-: "${QWEN_TTS_URL_LAZY:=http://127.0.0.1:18883}"
-: "${QWEN_TTS_QUALITY:=hq}"
-# Optional helper that lazily starts the :18883 server (see the Qwen3-TTS repo).
-# Override with QWEN_TTS_LAZY_ENSURE_SH; if absent, qwen-lazy degrades gracefully.
-: "${QWEN_TTS_LAZY_ENSURE_SH:=$HOME/Qwen3-TTS-Openai-Fastapi/qwen-lazy-ensure.sh}"
-if [ -z "${QWEN_TTS_URL:-}" ]; then
-    case "$(printf '%s' "$QWEN_TTS_QUALITY" | tr '[:upper:]' '[:lower:]')" in
-        hq|high|best|1.7b|large)  QWEN_TTS_URL="$QWEN_TTS_URL_HQ" ;;
-        lazy|lazy-1.7b|qwen-lazy) QWEN_TTS_URL="$QWEN_TTS_URL_LAZY" ;;
-        *)                        QWEN_TTS_URL="$QWEN_TTS_URL_FAST" ;;
-    esac
-fi
-: "${QWEN_TTS_VOICE:=vivian}"
-: "${QWEN_TTS_MODEL:=qwen3-tts}"
-: "${QWEN_TTS_SPEED:=1.0}"
-: "${XAI_API_KEY:=${XAI_API_KEY:-}}"
-: "${XAI_TTS_VOICE:=eve}"
-: "${XAI_TTS_MODEL:=grok-2-audio}"
-: "${SUPERTONIC_URL:=http://127.0.0.1:8765}"
-: "${SUPERTONIC_SH:=$HOME/.config/opencode/skills/supertonic-tts/supertonic.sh}"
-: "${SUPERTONIC_VOICE:=F4}"   # Supertonic 3 voices: F1–F5 / M1–M5 (default F4)
-# Quality presets: normal = 8 steps (fast), high = 20 steps (best). Set
-# TTS_QUALITY=high for HQ, or override SUPERTONIC_STEPS=<1-20> directly (wins).
-: "${TTS_QUALITY:=high}"
-case "$(printf '%s' "${TTS_QUALITY}" | tr '[:upper:]' '[:lower:]')" in
-    high|hq|best) _q_steps=20 ;;
-    *)            _q_steps=8  ;;
-esac
-: "${SUPERTONIC_STEPS:=$_q_steps}"   # denoising steps (1–20)
-: "${SUPERTONIC_SPEED:=1.0}"
-: "${NEUTTS_URL:=http://127.0.0.1:8020}"
-: "${NEUTTS_MODEL:=neuphonic/neutts-nano-q8-gguf}"
-: "${NEUTTS_MODEL_ES:=neuphonic/neutts-nano-spanish-q8-gguf}"
-: "${NEUTTS_MODEL_DE:=neuphonic/neutts-nano-german-q8-gguf}"
-: "${NEUTTS_MODEL_FR:=neuphonic/neutts-nano-french-q8-gguf}"
-# Inflect-Nano-v1 — ultra-small local CPU TTS (4.63M params, English-only, male voice "mark").
-# 10-13x realtime. Experimental quality. English-only (bails on other languages).
-: "${INFLECT_URL:=http://127.0.0.1:8030}"
-# Generic OpenAI-compatible remote TTS (for slow CPUs / no local backend). Works
-# with OpenAI's own /v1/audio/speech, a hosted provider, or your own remote box
-# running any OpenAI-compatible speech server. Defaults target OpenAI; override
-# OPENAI_TTS_URL for other providers. See docs/providers.md.
-: "${OPENAI_TTS_URL:=https://api.openai.com/v1}"
-: "${OPENAI_TTS_KEY:=${OPENAI_API_KEY:-}}"
-: "${OPENAI_TTS_MODEL:=gpt-4o-mini-tts}"
-: "${OPENAI_TTS_VOICE:=alloy}"
-: "${OPENAI_TTS_FORMAT:=wav}"
-# Inworld TTS (cloud, Basic auth). Model: inworld-tts-2 / inworld-tts-2-max.
-# Voice: built-ins like Ashley, Dennis, Mark, Olivia, etc. (see list-voices API).
-# Requires INWORLD_API_KEY env var. Get a key: https://platform.inworld.ai/api-keys
-: "${INWORLD_TTS_VOICE:=Ashley}"
-: "${INWORLD_TTS_MODEL:=inworld-tts-2}"
-: "${INWORLD_TTS_URL:=https://api.inworld.ai/tts/v1/voice}"
-# Inworld returns LINEAR16 by default at 48 kHz mono — playable by afplay/ffplay.
-: "${INWORLD_TTS_ENCODING:=LINEAR16}"
-: "${INWORLD_TTS_SAMPLE_RATE:=48000}"
-# Accept either INWORLD_API_KEY or INWORLD_TTS_API (some shells export the latter).
-: "${INWORLD_API_KEY:=${INWORLD_TTS_API:-}}"
-# -----------------------------------------------------------------------------
-
-# shellcheck source=tts_lang.sh
-. "${TTS_LANG_SH:=$HOME/.config/opencode/tts_lang.sh}"
-
-TEXT="${1:-Hello.}"
-OUTPUT="/tmp/opencode-speech.wav"
-LANG="$(resolve_lang "${2:-}" "$TEXT")"
-
-: "${TTS_NO_PLAY:=0}"
-
-speak_neutts() {
-    local text="$1"
-    local lang="$2"
-    local model="$NEUTTS_MODEL"
-
-    case "$lang" in
-        es*)  model="${NEUTTS_MODEL_ES}" ;;
-        de*)  model="${NEUTTS_MODEL_DE}" ;;
-        fr*)  model="${NEUTTS_MODEL_FR}" ;;
-        en*|*) model="${NEUTTS_MODEL}" ;;
-    esac
-
-    echo "[tts] NeuTTS lang=${lang} model=${model}" >&2
-
-    local payload
-    payload=$(python3 -c "
-import json, sys
-d = {'text': sys.argv[1], 'model': sys.argv[3]}
-if sys.argv[2]:
-    d['language'] = sys.argv[2]
-print(json.dumps(d))
-" "$text" "$lang" "$model" 2>/dev/null || printf '{"text":"%s","model":"%s"}' "$text" "$model")
-
-    local http_code
-    http_code=$(curl -sS -m 120 \
-        -o "$OUTPUT" \
-        -w '%{http_code}' \
-        "${NEUTTS_URL}/v1/audio/speech" \
-        -H "Content-Type: application/json" \
-        -d "$payload") || {
-        echo "tts.sh: NeuTTS request failed (curl exit $?)" >&2
-        return 1
-    }
-
-    if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
-        echo "tts.sh: NeuTTS HTTP $http_code" >&2
-        rm -f "$OUTPUT"
-        return 1
-    fi
-
-    [ -f "$OUTPUT" ] && [ -s "$OUTPUT" ] || { echo "tts.sh: NeuTTS produced no audio" >&2; return 1; }
-    [ "$TTS_NO_PLAY" = "1" ] && { echo "$OUTPUT"; return 0; }
-    play_wav "$OUTPUT"
-    rm -f "$OUTPUT"
-}
-
-speak_inflect() {
-    local text="$1"
-    local lang="$2"
-
-    # Inflect-Nano is English-only — bail on non-English so the fallback chain handles it
-    case "$lang" in
-        en*) ;;
-        *) echo "[tts] Inflect-Nano is English-only, skipping (lang=${lang})" >&2; return 1 ;;
-    esac
-
-    echo "[tts] Inflect-Nano lang=${lang}" >&2
-
-    local payload
-    payload=$(python3 -c "
-import json, sys
-print(json.dumps({'text': sys.argv[1]}))
-" "$text" 2>/dev/null || printf '{"text":"%s"}' "$text")
-
-    local http_code
-    http_code=$(curl -sS -m 60 \
-        -o "$OUTPUT" \
-        -w '%{http_code}' \
-        "${INFLECT_URL}/v1/audio/speech" \
-        -H "Content-Type: application/json" \
-        -d "$payload") || {
-        echo "tts.sh: Inflect-Nano request failed (curl exit $?)" >&2
-        return 1
-    }
-
-    if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
-        echo "tts.sh: Inflect-Nano HTTP $http_code" >&2
-        rm -f "$OUTPUT"
-        return 1
-    fi
-
-    [ -f "$OUTPUT" ] && [ -s "$OUTPUT" ] || { echo "tts.sh: Inflect-Nano produced no audio" >&2; return 1; }
-    [ "$TTS_NO_PLAY" = "1" ] && { echo "$OUTPUT"; return 0; }
-    play_wav "$OUTPUT"
-    rm -f "$OUTPUT"
-}
-
-speak_xai() {
-    local text="$1"
-    local lang="$2"
-    local voice="${XAI_TTS_VOICE:-eve}"
-
-    if [ -z "$XAI_API_KEY" ]; then
+speak_xai_tagged() {
+    if [ -z "$XAI_KEY" ]; then
         echo "tts.sh: XAI_API_KEY not set" >&2
         return 1
     fi
-
-    echo "[tts] xAI lang=${lang} voice=${voice}" >&2
-
-    # TTS_NO_PLAY (barge-in mode) — use single-request path
-    if [ "${TTS_NO_PLAY:-0}" = "1" ]; then
-        _speak_xai_single "$text" "$lang" "$voice"
-        return $?
+    if [ ! -f "$TAGGER_PY" ]; then
+        echo "tts.sh: sentence tagger is missing: $TAGGER_PY" >&2
+        return 1
     fi
 
-    # Split into sentence chunks on . ! ?
-    local chunks_json
-    chunks_json=$(python3 -c "
-import sys, re, json
-text = sys.stdin.read().strip()
-parts = re.split(r'(?<=[.!?])\s+', text)
-merged, buf = [], ''
-for p in parts:
-    p = p.strip()
-    if not p:
-        continue
-    if buf:
-        buf = buf + ' ' + p
-    else:
-        buf = p
-    if len(buf.split()) >= 2:
-        merged.append(buf)
-        buf = ''
-if buf:
-    if merged:
-        merged[-1] = merged[-1] + ' ' + buf
-    else:
-        merged.append(buf)
-print(json.dumps(merged))
-" <<<"$text")
+    local report_file request_file output_file tag_status http_code
+    report_file="$(mktemp "${TMPDIR:-/tmp}/opencode-xai-tags.XXXXXX")"
+    request_file="$(mktemp "${TMPDIR:-/tmp}/opencode-xai-request.XXXXXX")"
+    output_file="$(mktemp "${TMPDIR:-/tmp}/opencode-xai-tagged.XXXXXX")"
 
-    local count
-    count=$(python3 -c "import json,sys; print(len(json.loads(sys.argv[1])))" "$chunks_json")
-
-    if [ "$count" -le 1 ]; then
-        _speak_xai_single "$text" "$lang" "$voice"
-        return $?
+    if ! printf '%s' "$TEXT" | python3 "$TAGGER_PY" \
+        --language "$LANG" --mode "$TAG_MODE" --format json >"$report_file"; then
+        echo "tts.sh: xAI sentence tagging failed" >&2
+        rm -f "$report_file" "$request_file" "$output_file"
+        return 1
+    fi
+    if ! tag_status="$(build_xai_request "$report_file" "$request_file")"; then
+        echo "tts.sh: xAI sentence-tag invariant failed" >&2
+        rm -f "$report_file" "$request_file" "$output_file"
+        return 1
     fi
 
-    echo "[tts] Chunking into $count sentences (parallel xAI)" >&2
-    _speak_xai_chunked "$chunks_json" "$count" "$lang" "$voice"
-}
-
-_speak_xai_single() {
-    local text="$1"
-    local lang="$2"
-    local voice="$3"
-
-    local input_json
-    input_json=$(printf '{"text":%s,"voice_id":"%s","language":"%s"}' \
-        "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$text")" \
-        "$voice" "$lang")
-
-    local http_code
-    http_code=$(curl -sS -m 60 \
-        -o "$OUTPUT" \
-        -w '%{http_code}' \
-        "https://api.x.ai/v1/tts" \
-        -H "Authorization: Bearer $XAI_API_KEY" \
+    echo "[tts] xAI voice=${XAI_VOICE} lang=${LANG} tagged_sentences=${tag_status} mode=${TAG_MODE}" >&2
+    http_code="$(curl -sS -m "${XAI_TTS_TIMEOUT_SECONDS:-60}" \
+        -o "$output_file" -w '%{http_code}' \
+        "$XAI_URL" \
+        -H "Authorization: Bearer $XAI_KEY" \
         -H "Content-Type: application/json" \
-        -d "$input_json") || {
+        --data-binary "@$request_file")" || {
         echo "tts.sh: xAI request failed (curl exit $?)" >&2
+        rm -f "$report_file" "$request_file" "$output_file"
         return 1
     }
+    rm -f "$report_file" "$request_file"
 
     if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
         echo "tts.sh: xAI HTTP $http_code" >&2
-        rm -f "$OUTPUT"
+        rm -f "$output_file"
+        return 1
+    fi
+    if [ ! -s "$output_file" ]; then
+        echo "tts.sh: xAI produced no audio" >&2
+        rm -f "$output_file"
         return 1
     fi
 
-    [ -f "$OUTPUT" ] && [ -s "$OUTPUT" ] || { echo "tts.sh: xAI produced no audio" >&2; return 1; }
-    [ "$TTS_NO_PLAY" = "1" ] && { echo "$OUTPUT"; return 0; }
-    play_wav "$OUTPUT"
-    rm -f "$OUTPUT"
-}
-
-_speak_xai_chunked() {
-    local chunks_json="$1"
-    local count="$2"
-    local lang="$3"
-    local voice="$4"
-
-    local chunk_dir
-    chunk_dir=$(mktemp -d /tmp/opencode-tts-chunks.XXXXXX)
-
-    # Fire all chunk TTS requests in parallel
-    local i chunk_text wav_prefix
-    for ((i=0; i<count; i++)); do
-        chunk_text=$(python3 -c "import json,sys; print(json.loads(sys.argv[1])[$i])" "$chunks_json")
-        wav_prefix="${chunk_dir}/chunk_$(printf '%03d' $i)"
-        (
-            input_json=$(printf '{"text":%s,"voice_id":"%s","language":"%s"}' \
-                "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$chunk_text")" \
-                "$voice" "$lang")
-            if curl -sS -m 30 -o "${wav_prefix}.wav" \
-                "https://api.x.ai/v1/tts" \
-                -H "Authorization: Bearer $XAI_API_KEY" \
-                -H "Content-Type: application/json" \
-                -d "$input_json" 2>/dev/null && [ -f "${wav_prefix}.wav" ] && [ -s "${wav_prefix}.wav" ]; then
-                touch "${wav_prefix}.ready"
-            else
-                echo "[tts] xAI chunk $i failed" >&2
-                touch "${wav_prefix}.failed"
-            fi
-        ) &
-    done
-
-    # Play in order — starts faster vs single-path, may still wait for late chunks
-    for ((i=0; i<count; i++)); do
-        wav_prefix="${chunk_dir}/chunk_$(printf '%03d' $i)"
-        while [ ! -f "${wav_prefix}.ready" ] && [ ! -f "${wav_prefix}.failed" ]; do
-            sleep 0.05
-        done
-        if [ -f "${wav_prefix}.ready" ]; then
-            play_wav "${wav_prefix}.wav"
-        fi
-    done
-
-    rm -rf "$chunk_dir"
-    return 0
-}
-
-speak_supertonic() {
-    local text="$1"
-    local lang="$2"
-
-    echo "[tts] Supertonic voice=${SUPERTONIC_VOICE} steps=${SUPERTONIC_STEPS} (${TTS_QUALITY}) lang=${lang} url=${SUPERTONIC_URL}" >&2
-
-    # Supertonic Express 3 exposes an OpenAI-compatible /v1/audio/speech endpoint:
-    # required field is `input`; voice is one of F1–F5 / M1–M5; lang via `lang_code`.
-    local payload
-    payload=$(python3 -c "
-import json, sys
-d = {'input': sys.argv[1], 'voice': sys.argv[3],
-     'response_format': 'wav', 'stream': False,
-     'total_steps': int(sys.argv[4]), 'speed': float(sys.argv[5])}
-if sys.argv[2]:
-    d['lang_code'] = sys.argv[2]
-print(json.dumps(d))
-" "$text" "$lang" "$SUPERTONIC_VOICE" "$SUPERTONIC_STEPS" "$SUPERTONIC_SPEED" 2>/dev/null \
-        || printf '{"input":"%s","voice":"%s","response_format":"wav"}' "$text" "$SUPERTONIC_VOICE")
-
-    local http_code
-    http_code=$(curl -sS -m 60 \
-        -o "$OUTPUT" \
-        -w '%{http_code}' \
-        "${SUPERTONIC_URL}/v1/audio/speech" \
-        -H "Content-Type: application/json" \
-        -d "$payload") || {
-        echo "tts.sh: Supertonic request failed (curl exit $?)" >&2
-        return 1
-    }
-
-    if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
-        echo "tts.sh: Supertonic HTTP $http_code" >&2
-        rm -f "$OUTPUT"
-        return 1
-    fi
-
-    [ -f "$OUTPUT" ] && [ -s "$OUTPUT" ] || { echo "tts.sh: Supertonic produced no audio" >&2; return 1; }
-    [ "$TTS_NO_PLAY" = "1" ] && { echo "$OUTPUT"; return 0; }
-    play_wav "$OUTPUT"
-    rm -f "$OUTPUT"
-}
-
-speak_qwen() {
-    local text="$1"
-    local lang="$2"
-
-    echo "[tts] Qwen3-TTS voice=${QWEN_TTS_VOICE} lang=${lang} url=${QWEN_TTS_URL}" >&2
-
-    # OpenAI-compatible payload. The model auto-detects language, so `lang`
-    # is logged but not sent. WAV avoids the mp3/pydub encode step.
-    local payload
-    payload=$(python3 -c "
-import json, sys
-d = {'model': sys.argv[2], 'input': sys.argv[1], 'voice': sys.argv[3],
-     'response_format': 'wav', 'speed': float(sys.argv[4])}
-print(json.dumps(d))
-" "$text" "$QWEN_TTS_MODEL" "$QWEN_TTS_VOICE" "$QWEN_TTS_SPEED" 2>/dev/null \
-        || printf '{"model":"%s","input":"%s","voice":"%s","response_format":"wav"}' "$QWEN_TTS_MODEL" "$text" "$QWEN_TTS_VOICE")
-
-    local http_code
-    http_code=$(curl -sS -m 60 \
-        -o "$OUTPUT" \
-        -w '%{http_code}' \
-        "${QWEN_TTS_URL}/v1/audio/speech" \
-        -H "Content-Type: application/json" \
-        -d "$payload") || {
-        echo "tts.sh: Qwen3-TTS request failed (curl exit $?)" >&2
-        return 1
-    }
-
-    if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
-        echo "tts.sh: Qwen3-TTS HTTP $http_code" >&2
-        rm -f "$OUTPUT"
-        return 1
-    fi
-
-    [ -f "$OUTPUT" ] && [ -s "$OUTPUT" ] || { echo "tts.sh: Qwen3-TTS produced no audio" >&2; return 1; }
-    [ "$TTS_NO_PLAY" = "1" ] && { echo "$OUTPUT"; return 0; }
-    play_wav "$OUTPUT"
-    rm -f "$OUTPUT"
-}
-
-speak_qwen_lazy() {
-    local text="$1"
-    local lang="$2"
-    local _ensure="${QWEN_TTS_LAZY_ENSURE_SH:-$HOME/Qwen3-TTS-Openai-Fastapi/qwen-lazy-ensure.sh}"
-    if [ -x "$_ensure" ]; then
-        "$_ensure" || echo "[tts] qwen-lazy ensure returned non-zero; trying anyway…" >&2
-    else
-        echo "[tts] qwen-lazy-ensure.sh not found at $_ensure — server may not start" >&2
-    fi
-    QWEN_TTS_URL="${QWEN_TTS_URL_LAZY:-http://127.0.0.1:18883}" speak_qwen "$text" "$lang"
-}
-
-# Steer one sentence into inworld-tts-2 delivery tags for expressive audio.
-# Fail-open: prints the ORIGINAL text on disable / missing script / any error, so
-# audio never blocks. Called PER CHUNK (inside the parallel synth jobs) so the LLM
-# rewrite of one sentence overlaps the synthesis of the others instead of being one
-# serial pre-pass over the whole reply. Steering script lives next to this file.
-_inworld_steer_text() {
-    local text="$1" lang="$2"
-    local steer_sh="${INWORLD_STEER_SH:-$(dirname "${BASH_SOURCE[0]}")/inworld_steer.sh}"
-    if [ "${INWORLD_STEER:-auto}" = "0" ] || [ ! -f "$steer_sh" ]; then
-        printf '%s' "$text"; return 0
-    fi
-    local out
-    if out=$(INWORLD_API_KEY="${INWORLD_API_KEY:-${INWORLD_TTS_API:-}}" \
-            INWORLD_TTS_MODEL="${INWORLD_TTS_MODEL:-inworld-tts-2}" \
-            bash "$steer_sh" "$text" "$lang" 2>/dev/null) && [ -n "$out" ]; then
-        printf '%s' "$out"
-    else
-        printf '%s' "$text"
-    fi
-}
-
-speak_inworld() {
-    local text="$1"
-    local lang="$2"
-    local voice="${INWORLD_TTS_VOICE:-Ashley}"
-
-    if [ -z "${INWORLD_API_KEY:-}" ]; then
-        echo "tts.sh: INWORLD_API_KEY not set" >&2
-        return 1
-    fi
-
-    # Map 2-letter lang code → BCP-47. Inworld accepts a wide set; pass en as en-US.
-    local bcp
-    case "$lang" in
-        es) bcp="es-ES" ;;
-        de) bcp="de-DE" ;;
-        fr) bcp="fr-FR" ;;
-        it) bcp="it-IT" ;;
-        pt) bcp="pt-BR" ;;
-        ja) bcp="ja-JP" ;;
-        ko) bcp="ko-KR" ;;
-        zh) bcp="zh-CN" ;;
-        ru) bcp="ru-RU" ;;
-        ar) bcp="ar-SA" ;;
-        hi) bcp="hi-IN" ;;
-        nl) bcp="nl-NL" ;;
-        pl) bcp="pl-PL" ;;
-        en|*) bcp="en-US" ;;
-    esac
-
-    echo "[tts] Inworld voice=${voice} model=${INWORLD_TTS_MODEL} lang=${bcp}" >&2
-
-    # Chunk into sentences, request in parallel — same pattern as xAI.
-    # TTS_NO_PLAY is handled inside _speak_inworld_chunked (concatenates all
-    # chunk WAVs into one file instead of playing sequentially).
-    local chunks_json
-    chunks_json=$(python3 -c "
-import sys, re, json
-text = sys.stdin.read().strip()
-parts = re.split(r'(?<=[.!?])\s+', text)
-merged, buf = [], ''
-for p in parts:
-    p = p.strip()
-    if not p:
-        continue
-    if buf:
-        buf = buf + ' ' + p
-    else:
-        buf = p
-    if len(buf.split()) >= 2:
-        merged.append(buf)
-        buf = ''
-if buf:
-    if merged:
-        merged[-1] = merged[-1] + ' ' + buf
-    else:
-        merged.append(buf)
-print(json.dumps(merged))
-" <<<"$text")
-
-    local count
-    count=$(python3 -c "import json,sys; print(len(json.loads(sys.argv[1])))" "$chunks_json")
-
-    if [ "$count" -le 1 ]; then
-        local single; single=$(_inworld_steer_text "$text" "$lang")
-        _speak_inworld_single "$single" "$bcp" "$voice"
-        return $?
-    fi
-
-    echo "[tts] Chunking into $count sentences (parallel Inworld)" >&2
-    _speak_inworld_chunked "$chunks_json" "$count" "$bcp" "$voice"
-}
-
-_speak_inworld_single() {
-    local text="$1"
-    local bcp="$2"
-    local voice="$3"
-
-    local input_json
-            input_json=$(python3 -c "
-import json, sys
-print(json.dumps({
-    'text': sys.argv[1],
-    'voiceId': sys.argv[2],
-    'modelId': sys.argv[3],
-    'language': sys.argv[4],
-    'audioConfig': {
-        'audioEncoding': sys.argv[5],
-        'sampleRateHertz': int(sys.argv[6]),
-    },
-    'deliveryMode': 'BALANCED',
-    'applyTextNormalization': 'ON',
-}))
-" "$text" "$voice" "${INWORLD_TTS_MODEL:-inworld-tts-2}" "$bcp" \
-        "${INWORLD_TTS_ENCODING:-LINEAR16}" "${INWORLD_TTS_SAMPLE_RATE:-48000}")
-
-    # Inworld returns JSON: { \"audioContent\": \"<base64-LINEAR16>\" }
-    # Decode into a real .wav container so afplay / ffplay can play it.
-    local body_json wav_tmp
-    wav_tmp=$(mktemp -t inworld.wav)
-    body_json=$(mktemp -t inworld.json)
-    local http_code
-    http_code=$(curl -sS -m 60 \
-        -o "$body_json" \
-        -w '%{http_code}' \
-        "$INWORLD_TTS_URL" \
-        -H "Authorization: Basic $INWORLD_API_KEY" \
-        -H "Content-Type: application/json" \
-        -d "$input_json") || {
-        echo "tts.sh: Inworld request failed (curl exit $?)" >&2
-        rm -f "$body_json" "$wav_tmp"
-        return 1
-    }
-
-    if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
-        echo "tts.sh: Inworld HTTP $http_code" >&2
-        cat "$body_json" >&2
-        # 401/403 = auth problem. Mark it so the caller can refuse silent fallback.
-        if [ "$http_code" = "401" ] || [ "$http_code" = "403" ]; then
-            INWORLD_LAST_AUTH_FAIL=1
-            export INWORLD_LAST_AUTH_FAIL
-        fi
-        rm -f "$body_json" "$wav_tmp"
-        return 1
-    fi
-
-    # Decode base64 audioContent into WAV (with proper header).
-    if ! python3 -c "
-import base64, json, struct, sys
-with open(sys.argv[1], 'rb') as f:
-    body = f.read()
-try:
-    data = json.loads(body)
-except Exception as e:
-    print('Inworld: invalid JSON response:', e, file=sys.stderr)
-    sys.exit(2)
-b64 = data.get('audioContent') or data.get('audio_content') or ''
-if not b64:
-    print('Inworld: response missing audioContent:', body[:200], file=sys.stderr)
-    sys.exit(3)
-raw = base64.b64decode(b64)
-# Build a minimal RIFF/WAVE header for raw LINEAR16 mono PCM.
-sr = int(sys.argv[2])
-ch = 1
-bps = 16
-data_size = len(raw)
-with open(sys.argv[3], 'wb') as out:
-    out.write(b'RIFF')
-    out.write(struct.pack('<I', 36 + data_size))
-    out.write(b'WAVE')
-    out.write(b'fmt ')
-    out.write(struct.pack('<I', 16))             # fmt chunk size
-    out.write(struct.pack('<H', 1))              # PCM
-    out.write(struct.pack('<H', ch))
-    out.write(struct.pack('<I', sr))
-    out.write(struct.pack('<I', sr * ch * bps // 8))
-    out.write(struct.pack('<H', ch * bps // 8))
-    out.write(struct.pack('<H', bps))
-    out.write(b'data')
-    out.write(struct.pack('<I', data_size))
-    out.write(raw)
-" "$body_json" "${INWORLD_TTS_SAMPLE_RATE:-48000}" "$wav_tmp"; then
-        echo "tts.sh: Inworld audio decode failed" >&2
-        rm -f "$body_json" "$wav_tmp"
-        return 1
-    fi
-    rm -f "$body_json"
-
-    [ -f "$wav_tmp" ] && [ -s "$wav_tmp" ] || { echo "tts.sh: Inworld produced no audio" >&2; rm -f "$wav_tmp"; return 1; }
-    # Fade edges — Inworld starts on a non-zero sample (onset click).
-    fade_wav_edges "$wav_tmp"
-    [ "$TTS_NO_PLAY" = "1" ] && {
-        echo "$wav_tmp"
+    if [ "$TTS_NO_PLAY" = "1" ]; then
+        echo "$output_file"
         return 0
-    }
-    play_wav "$wav_tmp"
-    rm -f "$wav_tmp"
-}
-
-_speak_inworld_chunked() {
-    local chunks_json="$1"
-    local count="$2"
-    local bcp="$3"
-    local voice="$4"
-
-    local chunk_dir
-    chunk_dir=$(mktemp -d /tmp/opencode-tts-inworld.XXXXXX)
-
-    local i chunk_text wav_prefix
-    for ((i=0; i<count; i++)); do
-        chunk_text=$(python3 -c "import json,sys; print(json.loads(sys.argv[1])[$i])" "$chunks_json")
-        wav_prefix="${chunk_dir}/chunk_$(printf '%03d' $i)"
-        (
-    # Steer this sentence in its own parallel job so the LLM rewrite overlaps
-    # the other chunks' synthesis instead of blocking up front.
-    chunk_text=$(_inworld_steer_text "$chunk_text" "$bcp")
-    input_json=$(python3 -c "
-import json, sys
-print(json.dumps({
-    'text': sys.argv[1],
-    'voiceId': sys.argv[2],
-    'modelId': sys.argv[3],
-    'language': sys.argv[4],
-    'audioConfig': {
-        'audioEncoding': sys.argv[5],
-        'sampleRateHertz': int(sys.argv[6]),
-    },
-    'deliveryMode': 'BALANCED',
-    'applyTextNormalization': 'ON',
-}))
-" "$chunk_text" "$voice" "${INWORLD_TTS_MODEL:-inworld-tts-2}" "$bcp" \
-                    "${INWORLD_TTS_ENCODING:-LINEAR16}" "${INWORLD_TTS_SAMPLE_RATE:-48000}")
-
-            body_json=$(mktemp)
-            chunk_http=$(curl -sS -m 30 -o "$body_json" \
-                -w '%{http_code}' \
-                "$INWORLD_TTS_URL" \
-                -H "Authorization: Basic $INWORLD_API_KEY" \
-                -H "Content-Type: application/json" \
-                -d "$input_json" 2>/dev/null) || chunk_http=000
-            # If the whole batch is failing with 401/403, mark auth fail.
-            if [ "$chunk_http" = "401" ] || [ "$chunk_http" = "403" ]; then
-                INWORLD_LAST_AUTH_FAIL=1
-                export INWORLD_LAST_AUTH_FAIL
-            fi
-            if [ "$chunk_http" -ge 200 ] && [ "$chunk_http" -lt 300 ]; then
-                if python3 -c "
-import base64, json, struct, sys
-with open(sys.argv[1], 'rb') as f:
-    body = f.read()
-data = json.loads(body)
-b64 = data.get('audioContent') or data.get('audio_content') or ''
-if not b64: sys.exit(1)
-raw = base64.b64decode(b64)
-sr = int(sys.argv[2]); ch = 1; bps = 16
-with open(sys.argv[3] + '.wav', 'wb') as out:
-    out.write(b'RIFF'); out.write(struct.pack('<I', 36 + len(raw)))
-    out.write(b'WAVE'); out.write(b'fmt '); out.write(struct.pack('<I', 16))
-    out.write(struct.pack('<H', 1)); out.write(struct.pack('<H', ch))
-    out.write(struct.pack('<I', sr)); out.write(struct.pack('<I', sr * ch * bps // 8))
-    out.write(struct.pack('<H', ch * bps // 8)); out.write(struct.pack('<H', bps))
-    out.write(b'data'); out.write(struct.pack('<I', len(raw))); out.write(raw)
-" "$body_json" "${INWORLD_TTS_SAMPLE_RATE:-48000}" "$wav_prefix" 2>/dev/null; then
-                    # Fade each chunk's own edges — Inworld clips start on a
-                    # non-zero sample, so every chunk boundary pops without this.
-                    fade_wav_edges "${wav_prefix}.wav"
-                    touch "${wav_prefix}.ready"
-                else
-                    touch "${wav_prefix}.failed"
-                fi
-            else
-                touch "${wav_prefix}.failed"
-            fi
-            rm -f "$body_json"
-        ) &
-    done
-
-    if [ "${TTS_NO_PLAY:-0}" = "1" ]; then
-        # Barge-in mode needs the whole utterance as one WAV — wait for every
-        # chunk to finish, then concatenate below.
-        local ready_count=0
-        while [ "$ready_count" -lt "$count" ]; do
-            ready_count=0
-            local j
-            for ((j=0; j<count; j++)); do
-                wav_prefix="${chunk_dir}/chunk_$(printf '%03d' $j)"
-                if [ -f "${wav_prefix}.ready" ] || [ -f "${wav_prefix}.failed" ]; then
-                    ready_count=$((ready_count + 1))
-                fi
-            done
-            [ "$ready_count" -lt "$count" ] && sleep 0.05
-        done
-
-        local output_wav
-        output_wav=$(mktemp -t inworld-chunked.wav)
-        python3 -c "
-import wave, sys, os, struct
-output = sys.argv[1]
-chunk_dir = sys.argv[2]
-count = int(sys.argv[3])
-frames_list = []
-params = None
-for i in range(count):
-    path = f'{chunk_dir}/chunk_{i:03d}.wav'
-    if not os.path.exists(path):
-        continue
-    with wave.open(path, 'rb') as w:
-        if params is None:
-            params = w.getparams()
-        frames_list.append(w.readframes(w.getnframes()))
-if params is None:
-    sys.exit(1)
-with wave.open(output, 'wb') as out:
-    out.setparams(params)
-    out.writeframes(b''.join(frames_list))
-# 5ms fade-in/out — Inworld starts on a non-zero sample
-with wave.open(output, 'rb') as w:
-    params = w.getparams()
-    frames = w.readframes(w.getnframes())
-n = len(frames) // params.sampwidth
-fmt = {1:'b', 2:'h', 4:'i'}[params.sampwidth]
-samples = list(struct.unpack(f'<{n}{fmt}', frames))
-fade_n = int(params.framerate * 0.005)
-if fade_n > 0 and n > fade_n * 2:
-    for i in range(fade_n):
-        samples[i] = int(samples[i] * (i / fade_n))
-        samples[-(i+1)] = int(samples[-(i+1)] * (i / fade_n))
-with wave.open(output, 'wb') as w:
-    w.setparams(params)
-    w.writeframes(struct.pack(f'<{n}{fmt}', *samples))
-" "$output_wav" "$chunk_dir" "$count" 2>/dev/null && {
-            rm -rf "$chunk_dir"
-            echo "$output_wav"
-            return 0
-        }
-        rm -rf "$chunk_dir"
-        return 1
     fi
-
-    # Stream: play each chunk in order the instant it is ready, while later chunks
-    # are still being synthesized in parallel. First audio starts after chunk 0
-    # returns instead of after the whole reply finishes.
-    for ((i=0; i<count; i++)); do
-        wav_prefix="${chunk_dir}/chunk_$(printf '%03d' $i)"
-        while [ ! -f "${wav_prefix}.ready" ] && [ ! -f "${wav_prefix}.failed" ]; do
-            sleep 0.05
-        done
-        [ -f "${wav_prefix}.ready" ] && play_wav "${wav_prefix}.wav"
-    done
-
-    rm -rf "$chunk_dir"
-    return 0
+    play_wav "$output_file"
+    rm -f "$output_file"
 }
 
-# --- Generic OpenAI-compatible remote TTS (for slow CPUs) --------------------
-# Hits <OPENAI_TTS_URL>/audio/speech with the OpenAI speech schema. Streams by
-# sentence like xAI/Inworld: requests fire in parallel, playback starts on the
-# first sentence. Works with OpenAI and any OpenAI-compatible server.
-speak_openai() {
-    local text="$1" lang="$2"
-
-    if [ -z "${OPENAI_TTS_KEY:-}" ]; then
-        echo "tts.sh: OPENAI_TTS_KEY (or OPENAI_API_KEY) not set" >&2
-        return 1
-    fi
-    echo "[tts] OpenAI-compatible model=${OPENAI_TTS_MODEL} voice=${OPENAI_TTS_VOICE} url=${OPENAI_TTS_URL} lang=${lang}" >&2
-
-    if [ "${TTS_NO_PLAY:-0}" = "1" ]; then
-        _speak_openai_single "$text"
-        return $?
-    fi
-
-    # Split into sentence chunks on . ! ? (same merge rule as the other engines).
-    local chunks_json
-    chunks_json=$(python3 -c "
-import sys, re, json
-text = sys.stdin.read().strip()
-parts = re.split(r'(?<=[.!?])\s+', text)
-merged, buf = [], ''
-for p in parts:
-    p = p.strip()
-    if not p:
-        continue
-    buf = (buf + ' ' + p) if buf else p
-    if len(buf.split()) >= 2:
-        merged.append(buf); buf = ''
-if buf:
-    if merged: merged[-1] = merged[-1] + ' ' + buf
-    else: merged.append(buf)
-print(json.dumps(merged))
-" <<<"$text")
-    local count
-    count=$(python3 -c "import json,sys; print(len(json.loads(sys.argv[1])))" "$chunks_json")
-    if [ "$count" -le 1 ]; then
-        _speak_openai_single "$text"
-        return $?
-    fi
-    echo "[tts] Chunking into $count sentences (parallel OpenAI-compatible)" >&2
-    _speak_openai_chunked "$chunks_json" "$count"
-}
-
-_openai_payload() {
-    python3 -c "
-import json, sys
-print(json.dumps({'model': sys.argv[2], 'input': sys.argv[1],
-                  'voice': sys.argv[3], 'response_format': sys.argv[4]}))
-" "$1" "$OPENAI_TTS_MODEL" "$OPENAI_TTS_VOICE" "$OPENAI_TTS_FORMAT"
-}
-
-_speak_openai_single() {
-    local text="$1" payload http_code
-    payload=$(_openai_payload "$text")
-    http_code=$(curl -sS -m 60 -o "$OUTPUT" -w '%{http_code}' \
-        "${OPENAI_TTS_URL%/}/audio/speech" \
-        -H "Authorization: Bearer $OPENAI_TTS_KEY" \
-        -H "Content-Type: application/json" \
-        -d "$payload") || { echo "tts.sh: OpenAI TTS request failed (curl exit $?)" >&2; return 1; }
-    if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
-        echo "tts.sh: OpenAI TTS HTTP $http_code" >&2; rm -f "$OUTPUT"; return 1
-    fi
-    [ -f "$OUTPUT" ] && [ -s "$OUTPUT" ] || { echo "tts.sh: OpenAI TTS produced no audio" >&2; return 1; }
-    [ "$TTS_NO_PLAY" = "1" ] && { echo "$OUTPUT"; return 0; }
-    play_wav "$OUTPUT"
-    rm -f "$OUTPUT"
-}
-
-_speak_openai_chunked() {
-    local chunks_json="$1" count="$2"
-    local chunk_dir; chunk_dir=$(mktemp -d /tmp/opencode-tts-openai.XXXXXX)
-
-    local i chunk_text wav_prefix
-    for ((i=0; i<count; i++)); do
-        chunk_text=$(python3 -c "import json,sys; print(json.loads(sys.argv[1])[$i])" "$chunks_json")
-        wav_prefix="${chunk_dir}/chunk_$(printf '%03d' $i)"
-        (
-            payload=$(_openai_payload "$chunk_text")
-            if curl -sS -m 30 -o "${wav_prefix}.wav" \
-                "${OPENAI_TTS_URL%/}/audio/speech" \
-                -H "Authorization: Bearer $OPENAI_TTS_KEY" \
-                -H "Content-Type: application/json" \
-                -d "$payload" 2>/dev/null && [ -s "${wav_prefix}.wav" ]; then
-                touch "${wav_prefix}.ready"
-            else
-                echo "[tts] OpenAI chunk $i failed" >&2
-                touch "${wav_prefix}.failed"
-            fi
-        ) &
-    done
-
-    for ((i=0; i<count; i++)); do
-        wav_prefix="${chunk_dir}/chunk_$(printf '%03d' $i)"
-        while [ ! -f "${wav_prefix}.ready" ] && [ ! -f "${wav_prefix}.failed" ]; do
-            sleep 0.05
-        done
-        [ -f "${wav_prefix}.ready" ] && play_wav "${wav_prefix}.wav"
-    done
-    rm -rf "$chunk_dir"
-    return 0
-}
-
-# --- Fallback policy ---------------------------------------------------------
-# Always exhaust the LOCAL engines before the xAI cloud. The selected engine
-# runs first, then the remaining local engine(s); xAI is the final resort, used
-# only if every local engine fails. Selecting TTS_ENGINE=xai explicitly honors
-# that choice first, then still falls back to the local engines.
-engine="$(printf '%s' "${TTS_ENGINE}" | tr '[:upper:]' '[:lower:]')"
-case "$engine" in
-    qwen|qwen3|qwen3-tts|qwen-tts)
-        if speak_qwen "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] Qwen3-TTS failed → trying Supertonic (local)…" >&2
-        if speak_supertonic "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] Supertonic failed → trying NeuTTS (local)…" >&2
-        if speak_neutts "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] NeuTTS failed → xAI cloud (last resort)…" >&2
-        if speak_xai "$TEXT" "$LANG"; then exit 0; fi
-        echo "tts.sh: all TTS engines failed; no macOS say fallback is available" >&2
-        exit 1
-        ;;
-    supertonic|coreml-tts)
-        if speak_supertonic "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] Supertonic failed → trying NeuTTS (local)…" >&2
-        if speak_neutts "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] NeuTTS failed → xAI cloud (last resort)…" >&2
-        if speak_xai "$TEXT" "$LANG"; then exit 0; fi
-        echo "tts.sh: all TTS engines failed; no macOS say fallback is available" >&2
-        exit 1
-        ;;
-    neutts|neuphonic)
-        if speak_neutts "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] NeuTTS failed → trying Inflect-Nano (local, English)…" >&2
-        if speak_inflect "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] Inflect-Nano failed → trying Supertonic (local)…" >&2
-        if speak_supertonic "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] Supertonic failed → xAI cloud (last resort)…" >&2
-        if speak_xai "$TEXT" "$LANG"; then exit 0; fi
-        echo "tts.sh: all TTS engines failed; no macOS say fallback is available" >&2
-        exit 1
-        ;;
-    inflect|inflect-nano)
-        if speak_inflect "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] Inflect-Nano failed → trying NeuTTS (local)…" >&2
-        if speak_neutts "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] NeuTTS failed → trying Supertonic (local)…" >&2
-        if speak_supertonic "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] Supertonic failed → xAI cloud (last resort)…" >&2
-        if speak_xai "$TEXT" "$LANG"; then exit 0; fi
-        echo "tts.sh: all TTS engines failed; no macOS say fallback is available" >&2
-        exit 1
-        ;;
-    xai)
-        # Explicit cloud selection: honored first, then local fallbacks.
-        if speak_xai "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] xAI failed → trying Supertonic (local)…" >&2
-        if speak_supertonic "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] Supertonic failed → trying NeuTTS (local)…" >&2
-        if speak_neutts "$TEXT" "$LANG"; then exit 0; fi
-        echo "tts.sh: all TTS engines failed; no macOS say fallback is available" >&2
-        exit 1
-        ;;
-    inworld)
-        # Explicit cloud selection: honored first, then local fallbacks.
-        if speak_inworld "$TEXT" "$LANG"; then exit 0; fi
-        # If Inworld failed for a credential reason (401/403), do NOT fall back to
-        # local engines silently — the user explicitly asked for Inworld and a
-        # bad key needs to be fixed, not papered over. Surface the error loudly.
-        if [ "${INWORLD_LAST_AUTH_FAIL:-0}" = "1" ]; then
-            echo "" >&2
-            echo "tts.sh: Inworld rejected the API key (HTTP 401/403)." >&2
-            echo "       Refusing to silently fall back to local engines." >&2
-            echo "       Fix: regenerate a 'Basic (Base64)' key at" >&2
-            echo "         https://platform.inworld.ai/api-keys" >&2
-            echo "       Then update INWORLD_TTS_API in ~/.zshrc (or run" >&2
-            echo "         'inworld auth login && inworld auth print-api-key > ~/.inworld_api_key')." >&2
-            exit 3
+case "$ENGINE" in
+    xai|grok|x-ai)
+        if speak_xai_tagged; then
+            exit 0
         fi
-        echo "[tts] Inworld failed (non-auth) → trying Qwen3-TTS (local)…" >&2
-        if speak_qwen "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] Qwen3-TTS failed → trying Supertonic (local)…" >&2
-        if speak_supertonic "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] Supertonic failed → trying NeuTTS (local)…" >&2
-        if speak_neutts "$TEXT" "$LANG"; then exit 0; fi
-        echo "tts.sh: all TTS engines failed; no macOS say fallback is available" >&2
-        exit 1
-        ;;
-    openai|openai-tts)
-        # Remote OpenAI-compatible (slow-CPU offload): honored first, then the
-        # local engines (Supertonic is the repo default, so it leads the fallback).
-        if speak_openai "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] OpenAI-compatible failed → trying Supertonic (local)…" >&2
-        if speak_supertonic "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] Supertonic failed → trying NeuTTS (local)…" >&2
-        if speak_neutts "$TEXT" "$LANG"; then exit 0; fi
-        echo "tts.sh: all TTS engines failed; no macOS say fallback is available" >&2
-        exit 1
-        ;;
-    qwen-lazy|lazy)
-        if speak_qwen_lazy "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] qwen-lazy failed → trying Supertonic (local)…" >&2
-        if speak_supertonic "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] Supertonic failed → trying NeuTTS (local)…" >&2
-        if speak_neutts "$TEXT" "$LANG"; then exit 0; fi
-        echo "[tts] NeuTTS failed → xAI cloud (last resort)…" >&2
-        if speak_xai "$TEXT" "$LANG"; then exit 0; fi
-        echo "tts.sh: all TTS engines failed; no macOS say fallback is available" >&2
-        exit 1
+        echo "[tts] Tagged xAI failed → trying local backends…" >&2
+        run_backends_without_xai supertonic
         ;;
     *)
-        echo "tts.sh: unknown TTS_ENGINE=${TTS_ENGINE}. Use: supertonic, qwen, qwen-lazy, neutts, inflect, openai, inworld, xai." >&2
-        exit 2
+        if run_backends_without_xai "$ENGINE"; then
+            exit 0
+        fi
+        if [ -n "$XAI_KEY" ]; then
+            echo "[tts] Local/selected backends failed → trying sentence-tagged xAI…" >&2
+            speak_xai_tagged
+        else
+            exit 1
+        fi
         ;;
 esac

--- a/service/tts_backends.sh
+++ b/service/tts_backends.sh
@@ -1,0 +1,1052 @@
+#!/bin/bash
+# tts.sh — Multi-engine TTS CLI for OpenCode / talk skill.
+#
+# Local engines:  supertonic (repo default) · qwen (MLX) · neutts
+# Remote engines (for slow CPUs): openai (any OpenAI-compatible /v1/audio/speech),
+#                  inworld (expressive, per-sentence steering), xai (last resort).
+# Set TTS_ENGINE to override. With a LOCAL primary, the local engines are always
+# tried before any cloud. Choosing a remote engine (openai/inworld/xai) honors that
+# choice first, then still falls back to local. macOS `say` is intentionally not used.
+#
+# Slow CPU? Point TTS_ENGINE=openai at any OpenAI-compatible endpoint (OpenAI, a
+# hosted provider, or your own remote box) to offload synthesis. See docs/providers.md.
+
+set -e
+
+# Cross-platform WAV playback (macOS afplay, Linux ffplay/aplay/paplay)
+play_wav() {
+    local f="$1"
+    [ -f "$f" ] || return 1
+    case "$(uname -s 2>/dev/null)" in
+        Darwin) afplay "$f" ;;
+        *)
+            if command -v ffplay &>/dev/null; then
+                ffplay -nodisp -autoexit -loglevel quiet "$f" 2>/dev/null
+            elif command -v aplay &>/dev/null; then
+                aplay -q "$f" 2>/dev/null
+            elif command -v paplay &>/dev/null; then
+                paplay "$f" 2>/dev/null
+            else
+                echo "[tts] No audio player found (install ffmpeg)" >&2; return 1
+            fi ;;
+    esac
+}
+
+# Apply a short fade-in/out to a WAV in place to kill onset/offset clicks.
+# Inworld (and some neural TTS) clips start on a non-zero sample — the first
+# sample jumps straight to ~60-99% of peak, an audible pop at the start of
+# every chunk/phrase. A few ms of fade ramps that to zero. Idempotent and
+# cheap; safe to call on any mono/stereo 8/16/32-bit PCM WAV.
+: "${TTS_FADE_MS:=6}"
+fade_wav_edges() {
+    local f="$1" ms="${2:-${TTS_FADE_MS:-6}}"
+    [ -f "$f" ] || return 1
+    [ "$ms" = "0" ] && return 0
+    python3 - "$f" "$ms" <<'PY' 2>/dev/null || return 0
+import wave, struct, sys
+path, ms = sys.argv[1], float(sys.argv[2])
+try:
+    with wave.open(path, 'rb') as w:
+        params = w.getparams()
+        frames = w.readframes(w.getnframes())
+except Exception:
+    sys.exit(0)
+sw = params.sampwidth
+fmt = {1:'b', 2:'h', 4:'i'}.get(sw)
+if fmt is None:
+    sys.exit(0)
+n = len(frames) // sw
+samples = list(struct.unpack(f'<{n}{fmt}', frames))
+ch = max(1, params.nchannels)
+fade_n = int(params.framerate * ms / 1000.0) * ch   # ramp length in samples
+if fade_n > 0 and n > fade_n * 2:
+    for i in range(fade_n):
+        g = i / fade_n
+        samples[i] = int(samples[i] * g)
+        samples[-(i+1)] = int(samples[-(i+1)] * g)
+    with wave.open(path, 'wb') as w:
+        w.setparams(params)
+        w.writeframes(struct.pack(f'<{n}{fmt}', *samples))
+PY
+}
+
+# --- Engine config -----------------------------------------------------------
+# Default engine is `supertonic` (zero-setup, on-device, no API key). The other
+# engines are OPTIONAL — opt in with TTS_ENGINE=<name>:
+#   qwen      — local MLX Qwen3-TTS server (Apple Silicon). Setup/server:
+#               https://github.com/groxaxo/Qwen3-TTS-Openai-Fastapi
+#   neutts    — local NeuTTS GGUF server
+#   inworld   — Inworld AI cloud (needs INWORLD_API_KEY / INWORLD_TTS_API)
+#   xai       — xAI Grok cloud (needs XAI_API_KEY); last-resort fallback
+: "${TTS_ENGINE:=supertonic}"
+# Qwen3-TTS — local MLX server (Apple Silicon), OpenAI-compatible
+# /v1/audio/speech. Native voices: serena, vivian, uncle_fu, ryan, aiden,
+# ono_anna, sohee, eric, dylan (OpenAI aliases alloy/nova/… also accepted).
+# The model auto-detects language, so no lang_code is sent. WAV keeps latency
+# low (no mp3/pydub encode step).
+# Server + setup: https://github.com/groxaxo/Qwen3-TTS-Openai-Fastapi
+#
+# Three CustomVoice MLX servers (see the Qwen3-TTS repo above):
+#   fast → 0.6B on :18881 (low latency)     hq → 1.7B on :18882 (always-on)
+#   lazy → 1.7B on :18883 (auto-start, 5-min idle timeout, frees VRAM when idle)
+# QWEN_TTS_QUALITY=fast|hq|lazy picks which. An explicit QWEN_TTS_URL overrides.
+: "${QWEN_TTS_URL_FAST:=http://127.0.0.1:18881}"
+: "${QWEN_TTS_URL_HQ:=http://127.0.0.1:18882}"
+: "${QWEN_TTS_URL_LAZY:=http://127.0.0.1:18883}"
+: "${QWEN_TTS_QUALITY:=hq}"
+# Optional helper that lazily starts the :18883 server (see the Qwen3-TTS repo).
+# Override with QWEN_TTS_LAZY_ENSURE_SH; if absent, qwen-lazy degrades gracefully.
+: "${QWEN_TTS_LAZY_ENSURE_SH:=$HOME/Qwen3-TTS-Openai-Fastapi/qwen-lazy-ensure.sh}"
+if [ -z "${QWEN_TTS_URL:-}" ]; then
+    case "$(printf '%s' "$QWEN_TTS_QUALITY" | tr '[:upper:]' '[:lower:]')" in
+        hq|high|best|1.7b|large)  QWEN_TTS_URL="$QWEN_TTS_URL_HQ" ;;
+        lazy|lazy-1.7b|qwen-lazy) QWEN_TTS_URL="$QWEN_TTS_URL_LAZY" ;;
+        *)                        QWEN_TTS_URL="$QWEN_TTS_URL_FAST" ;;
+    esac
+fi
+: "${QWEN_TTS_VOICE:=vivian}"
+: "${QWEN_TTS_MODEL:=qwen3-tts}"
+: "${QWEN_TTS_SPEED:=1.0}"
+: "${XAI_API_KEY:=${XAI_API_KEY:-}}"
+: "${XAI_TTS_VOICE:=eve}"
+: "${XAI_TTS_MODEL:=grok-2-audio}"
+: "${SUPERTONIC_URL:=http://127.0.0.1:8765}"
+: "${SUPERTONIC_SH:=$HOME/.config/opencode/skills/supertonic-tts/supertonic.sh}"
+: "${SUPERTONIC_VOICE:=F4}"   # Supertonic 3 voices: F1–F5 / M1–M5 (default F4)
+# Quality presets: normal = 8 steps (fast), high = 20 steps (best). Set
+# TTS_QUALITY=high for HQ, or override SUPERTONIC_STEPS=<1-20> directly (wins).
+: "${TTS_QUALITY:=high}"
+case "$(printf '%s' "${TTS_QUALITY}" | tr '[:upper:]' '[:lower:]')" in
+    high|hq|best) _q_steps=20 ;;
+    *)            _q_steps=8  ;;
+esac
+: "${SUPERTONIC_STEPS:=$_q_steps}"   # denoising steps (1–20)
+: "${SUPERTONIC_SPEED:=1.0}"
+: "${NEUTTS_URL:=http://127.0.0.1:8020}"
+: "${NEUTTS_MODEL:=neuphonic/neutts-nano-q8-gguf}"
+: "${NEUTTS_MODEL_ES:=neuphonic/neutts-nano-spanish-q8-gguf}"
+: "${NEUTTS_MODEL_DE:=neuphonic/neutts-nano-german-q8-gguf}"
+: "${NEUTTS_MODEL_FR:=neuphonic/neutts-nano-french-q8-gguf}"
+# Inflect-Nano-v1 — ultra-small local CPU TTS (4.63M params, English-only, male voice "mark").
+# 10-13x realtime. Experimental quality. English-only (bails on other languages).
+: "${INFLECT_URL:=http://127.0.0.1:8030}"
+# Generic OpenAI-compatible remote TTS (for slow CPUs / no local backend). Works
+# with OpenAI's own /v1/audio/speech, a hosted provider, or your own remote box
+# running any OpenAI-compatible speech server. Defaults target OpenAI; override
+# OPENAI_TTS_URL for other providers. See docs/providers.md.
+: "${OPENAI_TTS_URL:=https://api.openai.com/v1}"
+: "${OPENAI_TTS_KEY:=${OPENAI_API_KEY:-}}"
+: "${OPENAI_TTS_MODEL:=gpt-4o-mini-tts}"
+: "${OPENAI_TTS_VOICE:=alloy}"
+: "${OPENAI_TTS_FORMAT:=wav}"
+# Inworld TTS (cloud, Basic auth). Model: inworld-tts-2 / inworld-tts-2-max.
+# Voice: built-ins like Ashley, Dennis, Mark, Olivia, etc. (see list-voices API).
+# Requires INWORLD_API_KEY env var. Get a key: https://platform.inworld.ai/api-keys
+: "${INWORLD_TTS_VOICE:=Ashley}"
+: "${INWORLD_TTS_MODEL:=inworld-tts-2}"
+: "${INWORLD_TTS_URL:=https://api.inworld.ai/tts/v1/voice}"
+# Inworld returns LINEAR16 by default at 48 kHz mono — playable by afplay/ffplay.
+: "${INWORLD_TTS_ENCODING:=LINEAR16}"
+: "${INWORLD_TTS_SAMPLE_RATE:=48000}"
+# Accept either INWORLD_API_KEY or INWORLD_TTS_API (some shells export the latter).
+: "${INWORLD_API_KEY:=${INWORLD_TTS_API:-}}"
+# -----------------------------------------------------------------------------
+
+# shellcheck source=tts_lang.sh
+. "${TTS_LANG_SH:=$HOME/.config/opencode/tts_lang.sh}"
+
+TEXT="${1:-Hello.}"
+OUTPUT="/tmp/opencode-speech.wav"
+LANG="$(resolve_lang "${2:-}" "$TEXT")"
+
+: "${TTS_NO_PLAY:=0}"
+
+speak_neutts() {
+    local text="$1"
+    local lang="$2"
+    local model="$NEUTTS_MODEL"
+
+    case "$lang" in
+        es*)  model="${NEUTTS_MODEL_ES}" ;;
+        de*)  model="${NEUTTS_MODEL_DE}" ;;
+        fr*)  model="${NEUTTS_MODEL_FR}" ;;
+        en*|*) model="${NEUTTS_MODEL}" ;;
+    esac
+
+    echo "[tts] NeuTTS lang=${lang} model=${model}" >&2
+
+    local payload
+    payload=$(python3 -c "
+import json, sys
+d = {'text': sys.argv[1], 'model': sys.argv[3]}
+if sys.argv[2]:
+    d['language'] = sys.argv[2]
+print(json.dumps(d))
+" "$text" "$lang" "$model" 2>/dev/null || printf '{"text":"%s","model":"%s"}' "$text" "$model")
+
+    local http_code
+    http_code=$(curl -sS -m 120 \
+        -o "$OUTPUT" \
+        -w '%{http_code}' \
+        "${NEUTTS_URL}/v1/audio/speech" \
+        -H "Content-Type: application/json" \
+        -d "$payload") || {
+        echo "tts.sh: NeuTTS request failed (curl exit $?)" >&2
+        return 1
+    }
+
+    if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+        echo "tts.sh: NeuTTS HTTP $http_code" >&2
+        rm -f "$OUTPUT"
+        return 1
+    fi
+
+    [ -f "$OUTPUT" ] && [ -s "$OUTPUT" ] || { echo "tts.sh: NeuTTS produced no audio" >&2; return 1; }
+    [ "$TTS_NO_PLAY" = "1" ] && { echo "$OUTPUT"; return 0; }
+    play_wav "$OUTPUT"
+    rm -f "$OUTPUT"
+}
+
+speak_inflect() {
+    local text="$1"
+    local lang="$2"
+
+    # Inflect-Nano is English-only — bail on non-English so the fallback chain handles it
+    case "$lang" in
+        en*) ;;
+        *) echo "[tts] Inflect-Nano is English-only, skipping (lang=${lang})" >&2; return 1 ;;
+    esac
+
+    echo "[tts] Inflect-Nano lang=${lang}" >&2
+
+    local payload
+    payload=$(python3 -c "
+import json, sys
+print(json.dumps({'text': sys.argv[1]}))
+" "$text" 2>/dev/null || printf '{"text":"%s"}' "$text")
+
+    local http_code
+    http_code=$(curl -sS -m 60 \
+        -o "$OUTPUT" \
+        -w '%{http_code}' \
+        "${INFLECT_URL}/v1/audio/speech" \
+        -H "Content-Type: application/json" \
+        -d "$payload") || {
+        echo "tts.sh: Inflect-Nano request failed (curl exit $?)" >&2
+        return 1
+    }
+
+    if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+        echo "tts.sh: Inflect-Nano HTTP $http_code" >&2
+        rm -f "$OUTPUT"
+        return 1
+    fi
+
+    [ -f "$OUTPUT" ] && [ -s "$OUTPUT" ] || { echo "tts.sh: Inflect-Nano produced no audio" >&2; return 1; }
+    [ "$TTS_NO_PLAY" = "1" ] && { echo "$OUTPUT"; return 0; }
+    play_wav "$OUTPUT"
+    rm -f "$OUTPUT"
+}
+
+speak_xai() {
+    local text="$1"
+    local lang="$2"
+    local voice="${XAI_TTS_VOICE:-eve}"
+
+    if [ -z "$XAI_API_KEY" ]; then
+        echo "tts.sh: XAI_API_KEY not set" >&2
+        return 1
+    fi
+
+    echo "[tts] xAI lang=${lang} voice=${voice}" >&2
+
+    # TTS_NO_PLAY (barge-in mode) — use single-request path
+    if [ "${TTS_NO_PLAY:-0}" = "1" ]; then
+        _speak_xai_single "$text" "$lang" "$voice"
+        return $?
+    fi
+
+    # Split into sentence chunks on . ! ?
+    local chunks_json
+    chunks_json=$(python3 -c "
+import sys, re, json
+text = sys.stdin.read().strip()
+parts = re.split(r'(?<=[.!?])\s+', text)
+merged, buf = [], ''
+for p in parts:
+    p = p.strip()
+    if not p:
+        continue
+    if buf:
+        buf = buf + ' ' + p
+    else:
+        buf = p
+    if len(buf.split()) >= 2:
+        merged.append(buf)
+        buf = ''
+if buf:
+    if merged:
+        merged[-1] = merged[-1] + ' ' + buf
+    else:
+        merged.append(buf)
+print(json.dumps(merged))
+" <<<"$text")
+
+    local count
+    count=$(python3 -c "import json,sys; print(len(json.loads(sys.argv[1])))" "$chunks_json")
+
+    if [ "$count" -le 1 ]; then
+        _speak_xai_single "$text" "$lang" "$voice"
+        return $?
+    fi
+
+    echo "[tts] Chunking into $count sentences (parallel xAI)" >&2
+    _speak_xai_chunked "$chunks_json" "$count" "$lang" "$voice"
+}
+
+_speak_xai_single() {
+    local text="$1"
+    local lang="$2"
+    local voice="$3"
+
+    local input_json
+    input_json=$(printf '{"text":%s,"voice_id":"%s","language":"%s"}' \
+        "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$text")" \
+        "$voice" "$lang")
+
+    local http_code
+    http_code=$(curl -sS -m 60 \
+        -o "$OUTPUT" \
+        -w '%{http_code}' \
+        "https://api.x.ai/v1/tts" \
+        -H "Authorization: Bearer $XAI_API_KEY" \
+        -H "Content-Type: application/json" \
+        -d "$input_json") || {
+        echo "tts.sh: xAI request failed (curl exit $?)" >&2
+        return 1
+    }
+
+    if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+        echo "tts.sh: xAI HTTP $http_code" >&2
+        rm -f "$OUTPUT"
+        return 1
+    fi
+
+    [ -f "$OUTPUT" ] && [ -s "$OUTPUT" ] || { echo "tts.sh: xAI produced no audio" >&2; return 1; }
+    [ "$TTS_NO_PLAY" = "1" ] && { echo "$OUTPUT"; return 0; }
+    play_wav "$OUTPUT"
+    rm -f "$OUTPUT"
+}
+
+_speak_xai_chunked() {
+    local chunks_json="$1"
+    local count="$2"
+    local lang="$3"
+    local voice="$4"
+
+    local chunk_dir
+    chunk_dir=$(mktemp -d /tmp/opencode-tts-chunks.XXXXXX)
+
+    # Fire all chunk TTS requests in parallel
+    local i chunk_text wav_prefix
+    for ((i=0; i<count; i++)); do
+        chunk_text=$(python3 -c "import json,sys; print(json.loads(sys.argv[1])[$i])" "$chunks_json")
+        wav_prefix="${chunk_dir}/chunk_$(printf '%03d' $i)"
+        (
+            input_json=$(printf '{"text":%s,"voice_id":"%s","language":"%s"}' \
+                "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$chunk_text")" \
+                "$voice" "$lang")
+            if curl -sS -m 30 -o "${wav_prefix}.wav" \
+                "https://api.x.ai/v1/tts" \
+                -H "Authorization: Bearer $XAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -d "$input_json" 2>/dev/null && [ -f "${wav_prefix}.wav" ] && [ -s "${wav_prefix}.wav" ]; then
+                touch "${wav_prefix}.ready"
+            else
+                echo "[tts] xAI chunk $i failed" >&2
+                touch "${wav_prefix}.failed"
+            fi
+        ) &
+    done
+
+    # Play in order — starts faster vs single-path, may still wait for late chunks
+    for ((i=0; i<count; i++)); do
+        wav_prefix="${chunk_dir}/chunk_$(printf '%03d' $i)"
+        while [ ! -f "${wav_prefix}.ready" ] && [ ! -f "${wav_prefix}.failed" ]; do
+            sleep 0.05
+        done
+        if [ -f "${wav_prefix}.ready" ]; then
+            play_wav "${wav_prefix}.wav"
+        fi
+    done
+
+    rm -rf "$chunk_dir"
+    return 0
+}
+
+speak_supertonic() {
+    local text="$1"
+    local lang="$2"
+
+    echo "[tts] Supertonic voice=${SUPERTONIC_VOICE} steps=${SUPERTONIC_STEPS} (${TTS_QUALITY}) lang=${lang} url=${SUPERTONIC_URL}" >&2
+
+    # Supertonic Express 3 exposes an OpenAI-compatible /v1/audio/speech endpoint:
+    # required field is `input`; voice is one of F1–F5 / M1–M5; lang via `lang_code`.
+    local payload
+    payload=$(python3 -c "
+import json, sys
+d = {'input': sys.argv[1], 'voice': sys.argv[3],
+     'response_format': 'wav', 'stream': False,
+     'total_steps': int(sys.argv[4]), 'speed': float(sys.argv[5])}
+if sys.argv[2]:
+    d['lang_code'] = sys.argv[2]
+print(json.dumps(d))
+" "$text" "$lang" "$SUPERTONIC_VOICE" "$SUPERTONIC_STEPS" "$SUPERTONIC_SPEED" 2>/dev/null \
+        || printf '{"input":"%s","voice":"%s","response_format":"wav"}' "$text" "$SUPERTONIC_VOICE")
+
+    local http_code
+    http_code=$(curl -sS -m 60 \
+        -o "$OUTPUT" \
+        -w '%{http_code}' \
+        "${SUPERTONIC_URL}/v1/audio/speech" \
+        -H "Content-Type: application/json" \
+        -d "$payload") || {
+        echo "tts.sh: Supertonic request failed (curl exit $?)" >&2
+        return 1
+    }
+
+    if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+        echo "tts.sh: Supertonic HTTP $http_code" >&2
+        rm -f "$OUTPUT"
+        return 1
+    fi
+
+    [ -f "$OUTPUT" ] && [ -s "$OUTPUT" ] || { echo "tts.sh: Supertonic produced no audio" >&2; return 1; }
+    [ "$TTS_NO_PLAY" = "1" ] && { echo "$OUTPUT"; return 0; }
+    play_wav "$OUTPUT"
+    rm -f "$OUTPUT"
+}
+
+speak_qwen() {
+    local text="$1"
+    local lang="$2"
+
+    echo "[tts] Qwen3-TTS voice=${QWEN_TTS_VOICE} lang=${lang} url=${QWEN_TTS_URL}" >&2
+
+    # OpenAI-compatible payload. The model auto-detects language, so `lang`
+    # is logged but not sent. WAV avoids the mp3/pydub encode step.
+    local payload
+    payload=$(python3 -c "
+import json, sys
+d = {'model': sys.argv[2], 'input': sys.argv[1], 'voice': sys.argv[3],
+     'response_format': 'wav', 'speed': float(sys.argv[4])}
+print(json.dumps(d))
+" "$text" "$QWEN_TTS_MODEL" "$QWEN_TTS_VOICE" "$QWEN_TTS_SPEED" 2>/dev/null \
+        || printf '{"model":"%s","input":"%s","voice":"%s","response_format":"wav"}' "$QWEN_TTS_MODEL" "$text" "$QWEN_TTS_VOICE")
+
+    local http_code
+    http_code=$(curl -sS -m 60 \
+        -o "$OUTPUT" \
+        -w '%{http_code}' \
+        "${QWEN_TTS_URL}/v1/audio/speech" \
+        -H "Content-Type: application/json" \
+        -d "$payload") || {
+        echo "tts.sh: Qwen3-TTS request failed (curl exit $?)" >&2
+        return 1
+    }
+
+    if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+        echo "tts.sh: Qwen3-TTS HTTP $http_code" >&2
+        rm -f "$OUTPUT"
+        return 1
+    fi
+
+    [ -f "$OUTPUT" ] && [ -s "$OUTPUT" ] || { echo "tts.sh: Qwen3-TTS produced no audio" >&2; return 1; }
+    [ "$TTS_NO_PLAY" = "1" ] && { echo "$OUTPUT"; return 0; }
+    play_wav "$OUTPUT"
+    rm -f "$OUTPUT"
+}
+
+speak_qwen_lazy() {
+    local text="$1"
+    local lang="$2"
+    local _ensure="${QWEN_TTS_LAZY_ENSURE_SH:-$HOME/Qwen3-TTS-Openai-Fastapi/qwen-lazy-ensure.sh}"
+    if [ -x "$_ensure" ]; then
+        "$_ensure" || echo "[tts] qwen-lazy ensure returned non-zero; trying anyway…" >&2
+    else
+        echo "[tts] qwen-lazy-ensure.sh not found at $_ensure — server may not start" >&2
+    fi
+    QWEN_TTS_URL="${QWEN_TTS_URL_LAZY:-http://127.0.0.1:18883}" speak_qwen "$text" "$lang"
+}
+
+# Steer one sentence into inworld-tts-2 delivery tags for expressive audio.
+# Fail-open: prints the ORIGINAL text on disable / missing script / any error, so
+# audio never blocks. Called PER CHUNK (inside the parallel synth jobs) so the LLM
+# rewrite of one sentence overlaps the synthesis of the others instead of being one
+# serial pre-pass over the whole reply. Steering script lives next to this file.
+_inworld_steer_text() {
+    local text="$1" lang="$2"
+    local steer_sh="${INWORLD_STEER_SH:-$(dirname "${BASH_SOURCE[0]}")/inworld_steer.sh}"
+    if [ "${INWORLD_STEER:-auto}" = "0" ] || [ ! -f "$steer_sh" ]; then
+        printf '%s' "$text"; return 0
+    fi
+    local out
+    if out=$(INWORLD_API_KEY="${INWORLD_API_KEY:-${INWORLD_TTS_API:-}}" \
+            INWORLD_TTS_MODEL="${INWORLD_TTS_MODEL:-inworld-tts-2}" \
+            bash "$steer_sh" "$text" "$lang" 2>/dev/null) && [ -n "$out" ]; then
+        printf '%s' "$out"
+    else
+        printf '%s' "$text"
+    fi
+}
+
+speak_inworld() {
+    local text="$1"
+    local lang="$2"
+    local voice="${INWORLD_TTS_VOICE:-Ashley}"
+
+    if [ -z "${INWORLD_API_KEY:-}" ]; then
+        echo "tts.sh: INWORLD_API_KEY not set" >&2
+        return 1
+    fi
+
+    # Map 2-letter lang code → BCP-47. Inworld accepts a wide set; pass en as en-US.
+    local bcp
+    case "$lang" in
+        es) bcp="es-ES" ;;
+        de) bcp="de-DE" ;;
+        fr) bcp="fr-FR" ;;
+        it) bcp="it-IT" ;;
+        pt) bcp="pt-BR" ;;
+        ja) bcp="ja-JP" ;;
+        ko) bcp="ko-KR" ;;
+        zh) bcp="zh-CN" ;;
+        ru) bcp="ru-RU" ;;
+        ar) bcp="ar-SA" ;;
+        hi) bcp="hi-IN" ;;
+        nl) bcp="nl-NL" ;;
+        pl) bcp="pl-PL" ;;
+        en|*) bcp="en-US" ;;
+    esac
+
+    echo "[tts] Inworld voice=${voice} model=${INWORLD_TTS_MODEL} lang=${bcp}" >&2
+
+    # Chunk into sentences, request in parallel — same pattern as xAI.
+    # TTS_NO_PLAY is handled inside _speak_inworld_chunked (concatenates all
+    # chunk WAVs into one file instead of playing sequentially).
+    local chunks_json
+    chunks_json=$(python3 -c "
+import sys, re, json
+text = sys.stdin.read().strip()
+parts = re.split(r'(?<=[.!?])\s+', text)
+merged, buf = [], ''
+for p in parts:
+    p = p.strip()
+    if not p:
+        continue
+    if buf:
+        buf = buf + ' ' + p
+    else:
+        buf = p
+    if len(buf.split()) >= 2:
+        merged.append(buf)
+        buf = ''
+if buf:
+    if merged:
+        merged[-1] = merged[-1] + ' ' + buf
+    else:
+        merged.append(buf)
+print(json.dumps(merged))
+" <<<"$text")
+
+    local count
+    count=$(python3 -c "import json,sys; print(len(json.loads(sys.argv[1])))" "$chunks_json")
+
+    if [ "$count" -le 1 ]; then
+        local single; single=$(_inworld_steer_text "$text" "$lang")
+        _speak_inworld_single "$single" "$bcp" "$voice"
+        return $?
+    fi
+
+    echo "[tts] Chunking into $count sentences (parallel Inworld)" >&2
+    _speak_inworld_chunked "$chunks_json" "$count" "$bcp" "$voice"
+}
+
+_speak_inworld_single() {
+    local text="$1"
+    local bcp="$2"
+    local voice="$3"
+
+    local input_json
+            input_json=$(python3 -c "
+import json, sys
+print(json.dumps({
+    'text': sys.argv[1],
+    'voiceId': sys.argv[2],
+    'modelId': sys.argv[3],
+    'language': sys.argv[4],
+    'audioConfig': {
+        'audioEncoding': sys.argv[5],
+        'sampleRateHertz': int(sys.argv[6]),
+    },
+    'deliveryMode': 'BALANCED',
+    'applyTextNormalization': 'ON',
+}))
+" "$text" "$voice" "${INWORLD_TTS_MODEL:-inworld-tts-2}" "$bcp" \
+        "${INWORLD_TTS_ENCODING:-LINEAR16}" "${INWORLD_TTS_SAMPLE_RATE:-48000}")
+
+    # Inworld returns JSON: { \"audioContent\": \"<base64-LINEAR16>\" }
+    # Decode into a real .wav container so afplay / ffplay can play it.
+    local body_json wav_tmp
+    wav_tmp=$(mktemp -t inworld.wav)
+    body_json=$(mktemp -t inworld.json)
+    local http_code
+    http_code=$(curl -sS -m 60 \
+        -o "$body_json" \
+        -w '%{http_code}' \
+        "$INWORLD_TTS_URL" \
+        -H "Authorization: Basic $INWORLD_API_KEY" \
+        -H "Content-Type: application/json" \
+        -d "$input_json") || {
+        echo "tts.sh: Inworld request failed (curl exit $?)" >&2
+        rm -f "$body_json" "$wav_tmp"
+        return 1
+    }
+
+    if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+        echo "tts.sh: Inworld HTTP $http_code" >&2
+        cat "$body_json" >&2
+        # 401/403 = auth problem. Mark it so the caller can refuse silent fallback.
+        if [ "$http_code" = "401" ] || [ "$http_code" = "403" ]; then
+            INWORLD_LAST_AUTH_FAIL=1
+            export INWORLD_LAST_AUTH_FAIL
+        fi
+        rm -f "$body_json" "$wav_tmp"
+        return 1
+    fi
+
+    # Decode base64 audioContent into WAV (with proper header).
+    if ! python3 -c "
+import base64, json, struct, sys
+with open(sys.argv[1], 'rb') as f:
+    body = f.read()
+try:
+    data = json.loads(body)
+except Exception as e:
+    print('Inworld: invalid JSON response:', e, file=sys.stderr)
+    sys.exit(2)
+b64 = data.get('audioContent') or data.get('audio_content') or ''
+if not b64:
+    print('Inworld: response missing audioContent:', body[:200], file=sys.stderr)
+    sys.exit(3)
+raw = base64.b64decode(b64)
+# Build a minimal RIFF/WAVE header for raw LINEAR16 mono PCM.
+sr = int(sys.argv[2])
+ch = 1
+bps = 16
+data_size = len(raw)
+with open(sys.argv[3], 'wb') as out:
+    out.write(b'RIFF')
+    out.write(struct.pack('<I', 36 + data_size))
+    out.write(b'WAVE')
+    out.write(b'fmt ')
+    out.write(struct.pack('<I', 16))             # fmt chunk size
+    out.write(struct.pack('<H', 1))              # PCM
+    out.write(struct.pack('<H', ch))
+    out.write(struct.pack('<I', sr))
+    out.write(struct.pack('<I', sr * ch * bps // 8))
+    out.write(struct.pack('<H', ch * bps // 8))
+    out.write(struct.pack('<H', bps))
+    out.write(b'data')
+    out.write(struct.pack('<I', data_size))
+    out.write(raw)
+" "$body_json" "${INWORLD_TTS_SAMPLE_RATE:-48000}" "$wav_tmp"; then
+        echo "tts.sh: Inworld audio decode failed" >&2
+        rm -f "$body_json" "$wav_tmp"
+        return 1
+    fi
+    rm -f "$body_json"
+
+    [ -f "$wav_tmp" ] && [ -s "$wav_tmp" ] || { echo "tts.sh: Inworld produced no audio" >&2; rm -f "$wav_tmp"; return 1; }
+    # Fade edges — Inworld starts on a non-zero sample (onset click).
+    fade_wav_edges "$wav_tmp"
+    [ "$TTS_NO_PLAY" = "1" ] && {
+        echo "$wav_tmp"
+        return 0
+    }
+    play_wav "$wav_tmp"
+    rm -f "$wav_tmp"
+}
+
+_speak_inworld_chunked() {
+    local chunks_json="$1"
+    local count="$2"
+    local bcp="$3"
+    local voice="$4"
+
+    local chunk_dir
+    chunk_dir=$(mktemp -d /tmp/opencode-tts-inworld.XXXXXX)
+
+    local i chunk_text wav_prefix
+    for ((i=0; i<count; i++)); do
+        chunk_text=$(python3 -c "import json,sys; print(json.loads(sys.argv[1])[$i])" "$chunks_json")
+        wav_prefix="${chunk_dir}/chunk_$(printf '%03d' $i)"
+        (
+    # Steer this sentence in its own parallel job so the LLM rewrite overlaps
+    # the other chunks' synthesis instead of blocking up front.
+    chunk_text=$(_inworld_steer_text "$chunk_text" "$bcp")
+    input_json=$(python3 -c "
+import json, sys
+print(json.dumps({
+    'text': sys.argv[1],
+    'voiceId': sys.argv[2],
+    'modelId': sys.argv[3],
+    'language': sys.argv[4],
+    'audioConfig': {
+        'audioEncoding': sys.argv[5],
+        'sampleRateHertz': int(sys.argv[6]),
+    },
+    'deliveryMode': 'BALANCED',
+    'applyTextNormalization': 'ON',
+}))
+" "$chunk_text" "$voice" "${INWORLD_TTS_MODEL:-inworld-tts-2}" "$bcp" \
+                    "${INWORLD_TTS_ENCODING:-LINEAR16}" "${INWORLD_TTS_SAMPLE_RATE:-48000}")
+
+            body_json=$(mktemp)
+            chunk_http=$(curl -sS -m 30 -o "$body_json" \
+                -w '%{http_code}' \
+                "$INWORLD_TTS_URL" \
+                -H "Authorization: Basic $INWORLD_API_KEY" \
+                -H "Content-Type: application/json" \
+                -d "$input_json" 2>/dev/null) || chunk_http=000
+            # If the whole batch is failing with 401/403, mark auth fail.
+            if [ "$chunk_http" = "401" ] || [ "$chunk_http" = "403" ]; then
+                INWORLD_LAST_AUTH_FAIL=1
+                export INWORLD_LAST_AUTH_FAIL
+            fi
+            if [ "$chunk_http" -ge 200 ] && [ "$chunk_http" -lt 300 ]; then
+                if python3 -c "
+import base64, json, struct, sys
+with open(sys.argv[1], 'rb') as f:
+    body = f.read()
+data = json.loads(body)
+b64 = data.get('audioContent') or data.get('audio_content') or ''
+if not b64: sys.exit(1)
+raw = base64.b64decode(b64)
+sr = int(sys.argv[2]); ch = 1; bps = 16
+with open(sys.argv[3] + '.wav', 'wb') as out:
+    out.write(b'RIFF'); out.write(struct.pack('<I', 36 + len(raw)))
+    out.write(b'WAVE'); out.write(b'fmt '); out.write(struct.pack('<I', 16))
+    out.write(struct.pack('<H', 1)); out.write(struct.pack('<H', ch))
+    out.write(struct.pack('<I', sr)); out.write(struct.pack('<I', sr * ch * bps // 8))
+    out.write(struct.pack('<H', ch * bps // 8)); out.write(struct.pack('<H', bps))
+    out.write(b'data'); out.write(struct.pack('<I', len(raw))); out.write(raw)
+" "$body_json" "${INWORLD_TTS_SAMPLE_RATE:-48000}" "$wav_prefix" 2>/dev/null; then
+                    # Fade each chunk's own edges — Inworld clips start on a
+                    # non-zero sample, so every chunk boundary pops without this.
+                    fade_wav_edges "${wav_prefix}.wav"
+                    touch "${wav_prefix}.ready"
+                else
+                    touch "${wav_prefix}.failed"
+                fi
+            else
+                touch "${wav_prefix}.failed"
+            fi
+            rm -f "$body_json"
+        ) &
+    done
+
+    if [ "${TTS_NO_PLAY:-0}" = "1" ]; then
+        # Barge-in mode needs the whole utterance as one WAV — wait for every
+        # chunk to finish, then concatenate below.
+        local ready_count=0
+        while [ "$ready_count" -lt "$count" ]; do
+            ready_count=0
+            local j
+            for ((j=0; j<count; j++)); do
+                wav_prefix="${chunk_dir}/chunk_$(printf '%03d' $j)"
+                if [ -f "${wav_prefix}.ready" ] || [ -f "${wav_prefix}.failed" ]; then
+                    ready_count=$((ready_count + 1))
+                fi
+            done
+            [ "$ready_count" -lt "$count" ] && sleep 0.05
+        done
+
+        local output_wav
+        output_wav=$(mktemp -t inworld-chunked.wav)
+        python3 -c "
+import wave, sys, os, struct
+output = sys.argv[1]
+chunk_dir = sys.argv[2]
+count = int(sys.argv[3])
+frames_list = []
+params = None
+for i in range(count):
+    path = f'{chunk_dir}/chunk_{i:03d}.wav'
+    if not os.path.exists(path):
+        continue
+    with wave.open(path, 'rb') as w:
+        if params is None:
+            params = w.getparams()
+        frames_list.append(w.readframes(w.getnframes()))
+if params is None:
+    sys.exit(1)
+with wave.open(output, 'wb') as out:
+    out.setparams(params)
+    out.writeframes(b''.join(frames_list))
+# 5ms fade-in/out — Inworld starts on a non-zero sample
+with wave.open(output, 'rb') as w:
+    params = w.getparams()
+    frames = w.readframes(w.getnframes())
+n = len(frames) // params.sampwidth
+fmt = {1:'b', 2:'h', 4:'i'}[params.sampwidth]
+samples = list(struct.unpack(f'<{n}{fmt}', frames))
+fade_n = int(params.framerate * 0.005)
+if fade_n > 0 and n > fade_n * 2:
+    for i in range(fade_n):
+        samples[i] = int(samples[i] * (i / fade_n))
+        samples[-(i+1)] = int(samples[-(i+1)] * (i / fade_n))
+with wave.open(output, 'wb') as w:
+    w.setparams(params)
+    w.writeframes(struct.pack(f'<{n}{fmt}', *samples))
+" "$output_wav" "$chunk_dir" "$count" 2>/dev/null && {
+            rm -rf "$chunk_dir"
+            echo "$output_wav"
+            return 0
+        }
+        rm -rf "$chunk_dir"
+        return 1
+    fi
+
+    # Stream: play each chunk in order the instant it is ready, while later chunks
+    # are still being synthesized in parallel. First audio starts after chunk 0
+    # returns instead of after the whole reply finishes.
+    for ((i=0; i<count; i++)); do
+        wav_prefix="${chunk_dir}/chunk_$(printf '%03d' $i)"
+        while [ ! -f "${wav_prefix}.ready" ] && [ ! -f "${wav_prefix}.failed" ]; do
+            sleep 0.05
+        done
+        [ -f "${wav_prefix}.ready" ] && play_wav "${wav_prefix}.wav"
+    done
+
+    rm -rf "$chunk_dir"
+    return 0
+}
+
+# --- Generic OpenAI-compatible remote TTS (for slow CPUs) --------------------
+# Hits <OPENAI_TTS_URL>/audio/speech with the OpenAI speech schema. Streams by
+# sentence like xAI/Inworld: requests fire in parallel, playback starts on the
+# first sentence. Works with OpenAI and any OpenAI-compatible server.
+speak_openai() {
+    local text="$1" lang="$2"
+
+    if [ -z "${OPENAI_TTS_KEY:-}" ]; then
+        echo "tts.sh: OPENAI_TTS_KEY (or OPENAI_API_KEY) not set" >&2
+        return 1
+    fi
+    echo "[tts] OpenAI-compatible model=${OPENAI_TTS_MODEL} voice=${OPENAI_TTS_VOICE} url=${OPENAI_TTS_URL} lang=${lang}" >&2
+
+    if [ "${TTS_NO_PLAY:-0}" = "1" ]; then
+        _speak_openai_single "$text"
+        return $?
+    fi
+
+    # Split into sentence chunks on . ! ? (same merge rule as the other engines).
+    local chunks_json
+    chunks_json=$(python3 -c "
+import sys, re, json
+text = sys.stdin.read().strip()
+parts = re.split(r'(?<=[.!?])\s+', text)
+merged, buf = [], ''
+for p in parts:
+    p = p.strip()
+    if not p:
+        continue
+    buf = (buf + ' ' + p) if buf else p
+    if len(buf.split()) >= 2:
+        merged.append(buf); buf = ''
+if buf:
+    if merged: merged[-1] = merged[-1] + ' ' + buf
+    else: merged.append(buf)
+print(json.dumps(merged))
+" <<<"$text")
+    local count
+    count=$(python3 -c "import json,sys; print(len(json.loads(sys.argv[1])))" "$chunks_json")
+    if [ "$count" -le 1 ]; then
+        _speak_openai_single "$text"
+        return $?
+    fi
+    echo "[tts] Chunking into $count sentences (parallel OpenAI-compatible)" >&2
+    _speak_openai_chunked "$chunks_json" "$count"
+}
+
+_openai_payload() {
+    python3 -c "
+import json, sys
+print(json.dumps({'model': sys.argv[2], 'input': sys.argv[1],
+                  'voice': sys.argv[3], 'response_format': sys.argv[4]}))
+" "$1" "$OPENAI_TTS_MODEL" "$OPENAI_TTS_VOICE" "$OPENAI_TTS_FORMAT"
+}
+
+_speak_openai_single() {
+    local text="$1" payload http_code
+    payload=$(_openai_payload "$text")
+    http_code=$(curl -sS -m 60 -o "$OUTPUT" -w '%{http_code}' \
+        "${OPENAI_TTS_URL%/}/audio/speech" \
+        -H "Authorization: Bearer $OPENAI_TTS_KEY" \
+        -H "Content-Type: application/json" \
+        -d "$payload") || { echo "tts.sh: OpenAI TTS request failed (curl exit $?)" >&2; return 1; }
+    if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+        echo "tts.sh: OpenAI TTS HTTP $http_code" >&2; rm -f "$OUTPUT"; return 1
+    fi
+    [ -f "$OUTPUT" ] && [ -s "$OUTPUT" ] || { echo "tts.sh: OpenAI TTS produced no audio" >&2; return 1; }
+    [ "$TTS_NO_PLAY" = "1" ] && { echo "$OUTPUT"; return 0; }
+    play_wav "$OUTPUT"
+    rm -f "$OUTPUT"
+}
+
+_speak_openai_chunked() {
+    local chunks_json="$1" count="$2"
+    local chunk_dir; chunk_dir=$(mktemp -d /tmp/opencode-tts-openai.XXXXXX)
+
+    local i chunk_text wav_prefix
+    for ((i=0; i<count; i++)); do
+        chunk_text=$(python3 -c "import json,sys; print(json.loads(sys.argv[1])[$i])" "$chunks_json")
+        wav_prefix="${chunk_dir}/chunk_$(printf '%03d' $i)"
+        (
+            payload=$(_openai_payload "$chunk_text")
+            if curl -sS -m 30 -o "${wav_prefix}.wav" \
+                "${OPENAI_TTS_URL%/}/audio/speech" \
+                -H "Authorization: Bearer $OPENAI_TTS_KEY" \
+                -H "Content-Type: application/json" \
+                -d "$payload" 2>/dev/null && [ -s "${wav_prefix}.wav" ]; then
+                touch "${wav_prefix}.ready"
+            else
+                echo "[tts] OpenAI chunk $i failed" >&2
+                touch "${wav_prefix}.failed"
+            fi
+        ) &
+    done
+
+    for ((i=0; i<count; i++)); do
+        wav_prefix="${chunk_dir}/chunk_$(printf '%03d' $i)"
+        while [ ! -f "${wav_prefix}.ready" ] && [ ! -f "${wav_prefix}.failed" ]; do
+            sleep 0.05
+        done
+        [ -f "${wav_prefix}.ready" ] && play_wav "${wav_prefix}.wav"
+    done
+    rm -rf "$chunk_dir"
+    return 0
+}
+
+# --- Fallback policy ---------------------------------------------------------
+# Always exhaust the LOCAL engines before the xAI cloud. The selected engine
+# runs first, then the remaining local engine(s); xAI is the final resort, used
+# only if every local engine fails. Selecting TTS_ENGINE=xai explicitly honors
+# that choice first, then still falls back to the local engines.
+engine="$(printf '%s' "${TTS_ENGINE}" | tr '[:upper:]' '[:lower:]')"
+case "$engine" in
+    qwen|qwen3|qwen3-tts|qwen-tts)
+        if speak_qwen "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] Qwen3-TTS failed → trying Supertonic (local)…" >&2
+        if speak_supertonic "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] Supertonic failed → trying NeuTTS (local)…" >&2
+        if speak_neutts "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] NeuTTS failed → xAI cloud (last resort)…" >&2
+        if speak_xai "$TEXT" "$LANG"; then exit 0; fi
+        echo "tts.sh: all TTS engines failed; no macOS say fallback is available" >&2
+        exit 1
+        ;;
+    supertonic|coreml-tts)
+        if speak_supertonic "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] Supertonic failed → trying NeuTTS (local)…" >&2
+        if speak_neutts "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] NeuTTS failed → xAI cloud (last resort)…" >&2
+        if speak_xai "$TEXT" "$LANG"; then exit 0; fi
+        echo "tts.sh: all TTS engines failed; no macOS say fallback is available" >&2
+        exit 1
+        ;;
+    neutts|neuphonic)
+        if speak_neutts "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] NeuTTS failed → trying Inflect-Nano (local, English)…" >&2
+        if speak_inflect "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] Inflect-Nano failed → trying Supertonic (local)…" >&2
+        if speak_supertonic "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] Supertonic failed → xAI cloud (last resort)…" >&2
+        if speak_xai "$TEXT" "$LANG"; then exit 0; fi
+        echo "tts.sh: all TTS engines failed; no macOS say fallback is available" >&2
+        exit 1
+        ;;
+    inflect|inflect-nano)
+        if speak_inflect "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] Inflect-Nano failed → trying NeuTTS (local)…" >&2
+        if speak_neutts "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] NeuTTS failed → trying Supertonic (local)…" >&2
+        if speak_supertonic "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] Supertonic failed → xAI cloud (last resort)…" >&2
+        if speak_xai "$TEXT" "$LANG"; then exit 0; fi
+        echo "tts.sh: all TTS engines failed; no macOS say fallback is available" >&2
+        exit 1
+        ;;
+    xai)
+        # Explicit cloud selection: honored first, then local fallbacks.
+        if speak_xai "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] xAI failed → trying Supertonic (local)…" >&2
+        if speak_supertonic "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] Supertonic failed → trying NeuTTS (local)…" >&2
+        if speak_neutts "$TEXT" "$LANG"; then exit 0; fi
+        echo "tts.sh: all TTS engines failed; no macOS say fallback is available" >&2
+        exit 1
+        ;;
+    inworld)
+        # Explicit cloud selection: honored first, then local fallbacks.
+        if speak_inworld "$TEXT" "$LANG"; then exit 0; fi
+        # If Inworld failed for a credential reason (401/403), do NOT fall back to
+        # local engines silently — the user explicitly asked for Inworld and a
+        # bad key needs to be fixed, not papered over. Surface the error loudly.
+        if [ "${INWORLD_LAST_AUTH_FAIL:-0}" = "1" ]; then
+            echo "" >&2
+            echo "tts.sh: Inworld rejected the API key (HTTP 401/403)." >&2
+            echo "       Refusing to silently fall back to local engines." >&2
+            echo "       Fix: regenerate a 'Basic (Base64)' key at" >&2
+            echo "         https://platform.inworld.ai/api-keys" >&2
+            echo "       Then update INWORLD_TTS_API in ~/.zshrc (or run" >&2
+            echo "         'inworld auth login && inworld auth print-api-key > ~/.inworld_api_key')." >&2
+            exit 3
+        fi
+        echo "[tts] Inworld failed (non-auth) → trying Qwen3-TTS (local)…" >&2
+        if speak_qwen "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] Qwen3-TTS failed → trying Supertonic (local)…" >&2
+        if speak_supertonic "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] Supertonic failed → trying NeuTTS (local)…" >&2
+        if speak_neutts "$TEXT" "$LANG"; then exit 0; fi
+        echo "tts.sh: all TTS engines failed; no macOS say fallback is available" >&2
+        exit 1
+        ;;
+    openai|openai-tts)
+        # Remote OpenAI-compatible (slow-CPU offload): honored first, then the
+        # local engines (Supertonic is the repo default, so it leads the fallback).
+        if speak_openai "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] OpenAI-compatible failed → trying Supertonic (local)…" >&2
+        if speak_supertonic "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] Supertonic failed → trying NeuTTS (local)…" >&2
+        if speak_neutts "$TEXT" "$LANG"; then exit 0; fi
+        echo "tts.sh: all TTS engines failed; no macOS say fallback is available" >&2
+        exit 1
+        ;;
+    qwen-lazy|lazy)
+        if speak_qwen_lazy "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] qwen-lazy failed → trying Supertonic (local)…" >&2
+        if speak_supertonic "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] Supertonic failed → trying NeuTTS (local)…" >&2
+        if speak_neutts "$TEXT" "$LANG"; then exit 0; fi
+        echo "[tts] NeuTTS failed → xAI cloud (last resort)…" >&2
+        if speak_xai "$TEXT" "$LANG"; then exit 0; fi
+        echo "tts.sh: all TTS engines failed; no macOS say fallback is available" >&2
+        exit 1
+        ;;
+    *)
+        echo "tts.sh: unknown TTS_ENGINE=${TTS_ENGINE}. Use: supertonic, qwen, qwen-lazy, neutts, inflect, openai, inworld, xai." >&2
+        exit 2
+        ;;
+esac

--- a/service/xai_sentence_tagger.py
+++ b/service/xai_sentence_tagger.py
@@ -1,0 +1,564 @@
+#!/usr/bin/env python3
+"""Strict sentence-by-sentence xAI speech tagger for Local VoiceMode LLM.
+
+The helper uses an OpenAI-compatible LLM when configured and always validates the
+result. Missing, malformed, or source-rewriting model output is repaired with a
+deterministic provider-correct tag so every spoken sentence has at least one xAI
+speech tag before synthesis.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from typing import Any
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+XAI_INLINE_TAGS: tuple[str, ...] = (
+    "pause",
+    "long-pause",
+    "hum-tune",
+    "laugh",
+    "chuckle",
+    "giggle",
+    "cry",
+    "tsk",
+    "tongue-click",
+    "lip-smack",
+    "breath",
+    "inhale",
+    "exhale",
+    "sigh",
+)
+XAI_WRAPPING_TAGS: tuple[str, ...] = (
+    "soft",
+    "whisper",
+    "loud",
+    "build-intensity",
+    "decrease-intensity",
+    "higher-pitch",
+    "lower-pitch",
+    "slow",
+    "fast",
+    "sing-song",
+    "singing",
+    "laugh-speak",
+    "emphasis",
+)
+_INLINE_SET = frozenset(XAI_INLINE_TAGS)
+_WRAPPER_SET = frozenset(XAI_WRAPPING_TAGS)
+_TAG_AT_RE = re.compile(r"\[([a-z][a-z-]*)\]|<(\/)?([a-z][a-z-]*)>", re.IGNORECASE)
+_BOUNDARY_RE = re.compile(r"[.!?]+(?:[\"'”’»）)\]]+)?(?=\s+|$)", re.UNICODE)
+_JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
+_COMMON_ABBREVIATIONS = frozenset(
+    {
+        "mr.",
+        "mrs.",
+        "ms.",
+        "dr.",
+        "prof.",
+        "sr.",
+        "jr.",
+        "st.",
+        "vs.",
+        "etc.",
+        "e.g.",
+        "i.e.",
+        "no.",
+        "fig.",
+    }
+)
+
+
+class TaggingError(RuntimeError):
+    """Safe sentence-tagger failure."""
+
+
+@dataclass(frozen=True, slots=True)
+class SentenceSpan:
+    index: int
+    start: int
+    end: int
+    text: str
+
+
+@dataclass(frozen=True, slots=True)
+class TaggedSentence:
+    index: int
+    original: str
+    tagged_text: str
+    tags: tuple[str, ...]
+    source: str
+    warning: str | None = None
+
+
+def _env_text(name: str) -> str | None:
+    value = os.getenv(name)
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _is_abbreviation(text: str, boundary_start: int, boundary_end: int) -> bool:
+    punctuation = text[boundary_start:boundary_end]
+    if punctuation != ".":
+        return False
+    prefix = text[:boundary_end]
+    match = re.search(r"([A-Za-z](?:[A-Za-z.]*)\.)$", prefix)
+    if not match:
+        return False
+    token = match.group(1).casefold()
+    if token in _COMMON_ABBREVIATIONS:
+        return True
+    return len(token) == 2 and token[0].isalpha()
+
+
+def sentence_spans(text: str) -> list[SentenceSpan]:
+    """Split text into source-preserving sentence spans."""
+    spans: list[SentenceSpan] = []
+    start = 0
+    for match in _BOUNDARY_RE.finditer(text):
+        if _is_abbreviation(text, match.start(), match.end()):
+            continue
+        end = match.end()
+        segment = text[start:end]
+        if segment.strip():
+            spans.append(SentenceSpan(len(spans), start, end, segment))
+        start = end
+    if start < len(text):
+        segment = text[start:]
+        if segment.strip():
+            spans.append(SentenceSpan(len(spans), start, len(text), segment))
+    if not spans and text.strip():
+        spans.append(SentenceSpan(0, 0, len(text), text))
+    return spans
+
+
+def _split_outer_whitespace(text: str) -> tuple[str, str, str]:
+    leading_size = len(text) - len(text.lstrip())
+    trailing_size = len(text) - len(text.rstrip())
+    end = len(text) - trailing_size if trailing_size else len(text)
+    return text[:leading_size], text[leading_size:end], text[end:]
+
+
+def _tag_token_at(text: str, offset: int) -> tuple[int, str, bool] | None:
+    match = _TAG_AT_RE.match(text, offset)
+    if match is None:
+        return None
+    inline, closing, wrapper = match.groups()
+    if inline:
+        tag = inline.casefold()
+        return (match.end(), tag, True) if tag in _INLINE_SET else None
+    assert wrapper is not None
+    tag = wrapper.casefold()
+    if tag not in _WRAPPER_SET:
+        return None
+    return match.end(), tag, not bool(closing)
+
+
+def inserted_tags(original: str, tagged: str) -> tuple[list[str], bool]:
+    """Return newly inserted xAI tags and whether source text is exact."""
+    source_offset = 0
+    tagged_offset = 0
+    found: list[str] = []
+
+    while source_offset < len(original):
+        token = _tag_token_at(tagged, tagged_offset)
+        if token is not None:
+            end, tag, opening = token
+            literal = tagged[tagged_offset:end]
+            if not original.startswith(literal, source_offset):
+                if opening:
+                    found.append(tag)
+                tagged_offset = end
+                continue
+        if tagged_offset >= len(tagged) or tagged[tagged_offset] != original[source_offset]:
+            return [], False
+        tagged_offset += 1
+        source_offset += 1
+
+    while tagged_offset < len(tagged):
+        token = _tag_token_at(tagged, tagged_offset)
+        if token is None:
+            return [], False
+        tagged_offset, tag, opening = token
+        if opening:
+            found.append(tag)
+    return found, True
+
+
+def _wrapper_errors(tagged: str) -> list[str]:
+    stack: list[str] = []
+    errors: list[str] = []
+    for match in re.finditer(r"<(\/)?([a-z][a-z-]*)>", tagged, re.IGNORECASE):
+        closing, raw = match.groups()
+        tag = raw.casefold()
+        if tag not in _WRAPPER_SET:
+            continue
+        if not closing:
+            stack.append(tag)
+        elif not stack:
+            errors.append(f"closing </{tag}> has no opener")
+        else:
+            expected = stack.pop()
+            if expected != tag:
+                errors.append(f"expected </{expected}> but found </{tag}>")
+    errors.extend(f"unclosed <{tag}>" for tag in reversed(stack))
+    return errors
+
+
+def validate_tagged_sentence(original: str, tagged: str) -> tuple[list[str], list[str]]:
+    tags, preserved = inserted_tags(original, tagged)
+    errors: list[str] = []
+    if not preserved:
+        errors.append("tagged output changed the original sentence")
+    if not tags:
+        errors.append("sentence has no inserted xAI speech tag")
+    errors.extend(_wrapper_errors(tagged))
+    return errors, tags
+
+
+def deterministic_tag(sentence: str, index: int) -> TaggedSentence:
+    leading, core, trailing = _split_outer_whitespace(sentence)
+    if not core:
+        raise TaggingError(f"Sentence {index} is blank")
+    kind = "wrapper"
+    tag = "emphasis"
+
+    rules: tuple[tuple[re.Pattern[str], str, str], ...] = (
+        (
+            re.compile(r"\b(secret|secreto|susurr|whisper|quiet|silencio)\b", re.I),
+            "wrapper",
+            "whisper",
+        ),
+        (
+            re.compile(
+                r"\b(miedo|terror|panic|pánico|danger|peligro|sad|triste|dolor)\b",
+                re.I,
+            ),
+            "wrapper",
+            "lower-pitch",
+        ),
+        (
+            re.compile(r"\b(laugh|laughed|funny|risa|reí|gracioso|absurdo)\b", re.I),
+            "inline",
+            "chuckle",
+        ),
+        (
+            re.compile(r"\b(calm|calma|slow|lento|despacio|suave)\b", re.I),
+            "wrapper",
+            "slow",
+        ),
+        (
+            re.compile(
+                r"\b(fast|quick|urgent|urgencia|rápido|suddenly|de pronto)\b",
+                re.I,
+            ),
+            "wrapper",
+            "fast",
+        ),
+    )
+    for pattern, rule_kind, rule_tag in rules:
+        if pattern.search(core):
+            kind, tag = rule_kind, rule_tag
+            break
+    else:
+        if "!" in core:
+            kind, tag = "wrapper", "loud"
+        elif "?" in core:
+            kind, tag = "wrapper", "higher-pitch"
+        else:
+            cycle = (
+                ("wrapper", "emphasis"),
+                ("inline", "breath"),
+                ("wrapper", "soft"),
+                ("inline", "pause"),
+                ("wrapper", "build-intensity"),
+                ("inline", "sigh"),
+            )
+            kind, tag = cycle[index % len(cycle)]
+
+    if kind == "inline":
+        directed = f"[{tag}]{core}"
+    else:
+        directed = f"<{tag}>{core}</{tag}>"
+    tagged = leading + directed + trailing
+    errors, tags = validate_tagged_sentence(sentence, tagged)
+    if errors:
+        raise TaggingError(f"Deterministic tag failed for sentence {index}: {'; '.join(errors)}")
+    return TaggedSentence(index, sentence, tagged, tuple(tags), "deterministic")
+
+
+def _chat_completions_url(base_url: str) -> str:
+    value = base_url.rstrip("/")
+    if value.endswith("/chat/completions"):
+        return value
+    if value.endswith("/v1"):
+        return value + "/chat/completions"
+    return value + "/v1/chat/completions"
+
+
+def _llm_system_prompt(language: str) -> str:
+    inline = " ".join(f"[{tag}]" for tag in XAI_INLINE_TAGS)
+    wrapping = " ".join(f"<{tag}>...</{tag}>" for tag in XAI_WRAPPING_TAGS)
+    return f"""You are a strict xAI speech-direction editor.
+Add at least one valid xAI speech tag to EVERY supplied sentence while preserving every
+original character exactly. Return JSON only:
+{{"sentences":[{{"index":0,"tagged_text":"..."}}]}}
+
+Allowed inline tags:
+{inline}
+
+Allowed wrapping tags:
+{wrapping}
+
+Rules:
+1. One output row per input index; no missing or duplicate indexes.
+2. Every sentence must contain at least one newly inserted valid tag.
+3. Do not rewrite, translate, delete, reorder, correct, or normalize source characters.
+4. Usually use one contextually appropriate tag; avoid noisy over-tagging.
+5. Return no Markdown or commentary.
+6. Language hint: {language!r}. Preserve the language and dialect.
+"""
+
+
+def _extract_json_object(content: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(content)
+    except json.JSONDecodeError:
+        match = _JSON_OBJECT_RE.search(content)
+        if match is None:
+            raise TaggingError("Tagging model did not return JSON") from None
+        try:
+            payload = json.loads(match.group(0))
+        except json.JSONDecodeError as exc:
+            raise TaggingError("Tagging model returned malformed JSON") from exc
+    if not isinstance(payload, dict):
+        raise TaggingError("Tagging model response must be a JSON object")
+    return payload
+
+
+def _request_llm(sentences: list[SentenceSpan], language: str) -> dict[int, str]:
+    base_url = _env_text("TTS_TAGGER_URL") or _env_text("LLM_BASE_URL")
+    model = _env_text("TTS_TAGGER_MODEL") or _env_text("LLM_MODEL")
+    if not base_url or not model:
+        raise TaggingError("TTS_TAGGER_URL and TTS_TAGGER_MODEL are not configured")
+    key = _env_text("TTS_TAGGER_API_KEY") or _env_text("LLM_API_KEY")
+    try:
+        temperature = float(_env_text("TTS_TAGGER_TEMPERATURE") or "0.2")
+        timeout = float(_env_text("TTS_TAGGER_TIMEOUT_SECONDS") or "30")
+    except ValueError as exc:
+        raise TaggingError("TTS tagger temperature and timeout must be numeric") from exc
+    if timeout <= 0:
+        raise TaggingError("TTS_TAGGER_TIMEOUT_SECONDS must be greater than zero")
+
+    request_payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": _llm_system_prompt(language)},
+            {
+                "role": "user",
+                "content": json.dumps(
+                    {
+                        "sentences": [
+                            {"index": sentence.index, "text": sentence.text}
+                            for sentence in sentences
+                        ]
+                    },
+                    ensure_ascii=False,
+                ),
+            },
+        ],
+        "temperature": temperature,
+        "stream": False,
+        "response_format": {"type": "json_object"},
+    }
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if key and key != "not-needed":
+        headers["Authorization"] = f"Bearer {key}"
+
+    def send(payload: dict[str, Any]) -> dict[str, Any]:
+        req = urllib_request.Request(
+            _chat_completions_url(base_url),
+            data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urllib_request.urlopen(req, timeout=timeout) as response:
+                raw = response.read()
+        except urllib_error.HTTPError as exc:
+            detail = exc.read(1000).decode("utf-8", errors="replace").strip()
+            raise TaggingError(
+                f"Tagging model returned HTTP {exc.code}: {detail or exc.reason}"
+            ) from exc
+        except urllib_error.URLError as exc:
+            raise TaggingError(f"Cannot reach tagging model: {exc.reason}") from exc
+        except TimeoutError as exc:
+            raise TaggingError(f"Tagging model timed out after {timeout:g} seconds") from exc
+        try:
+            decoded = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise TaggingError("Tagging endpoint returned malformed JSON") from exc
+        if not isinstance(decoded, dict):
+            raise TaggingError("Tagging endpoint returned non-object JSON")
+        return decoded
+
+    try:
+        response = send(request_payload)
+    except TaggingError as first_error:
+        fallback_payload = dict(request_payload)
+        fallback_payload.pop("response_format", None)
+        try:
+            response = send(fallback_payload)
+        except TaggingError:
+            raise first_error
+
+    try:
+        content = response["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError) as exc:
+        raise TaggingError("Tagging endpoint response is missing choices[0].message.content") from exc
+    if not isinstance(content, str):
+        raise TaggingError("Tagging endpoint message content is not text")
+    payload = _extract_json_object(content)
+    rows = payload.get("sentences")
+    if not isinstance(rows, list):
+        raise TaggingError("Tagging model response is missing a sentences array")
+    result: dict[int, str] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        index = row.get("index")
+        tagged_text = row.get("tagged_text")
+        if isinstance(index, int) and isinstance(tagged_text, str) and index not in result:
+            result[index] = tagged_text
+    return result
+
+
+def tag_text(text: str, language: str = "auto", mode: str | None = None) -> dict[str, Any]:
+    if not text.strip():
+        raise TaggingError("Refusing to tag blank text")
+    selected_mode = (mode or _env_text("TTS_TAG_MODE") or "auto").strip().casefold()
+    if selected_mode not in {"auto", "llm", "deterministic"}:
+        raise TaggingError("TTS_TAG_MODE must be auto, llm, or deterministic")
+
+    spans = sentence_spans(text)
+    if not spans:
+        raise TaggingError("No spoken sentences were found")
+
+    llm_rows: dict[int, str] = {}
+    llm_warning: str | None = None
+    if selected_mode in {"auto", "llm"}:
+        try:
+            llm_rows = _request_llm(spans, language)
+        except TaggingError as exc:
+            llm_warning = str(exc)
+
+    tagged_sentences: list[TaggedSentence] = []
+    for sentence in spans:
+        candidate = llm_rows.get(sentence.index)
+        if candidate is not None:
+            errors, tags = validate_tagged_sentence(sentence.text, candidate)
+            if not errors:
+                tagged_sentences.append(
+                    TaggedSentence(
+                        sentence.index,
+                        sentence.text,
+                        candidate,
+                        tuple(tags),
+                        "llm",
+                        llm_warning,
+                    )
+                )
+                continue
+            warning = "; ".join(errors)
+        else:
+            warning = llm_warning or "Tagging model omitted this sentence"
+        repaired = deterministic_tag(sentence.text, sentence.index)
+        tagged_sentences.append(
+            TaggedSentence(
+                repaired.index,
+                repaired.original,
+                repaired.tagged_text,
+                repaired.tags,
+                repaired.source,
+                warning if selected_mode != "deterministic" else None,
+            )
+        )
+
+    if len(tagged_sentences) != len(spans):
+        raise TaggingError("Internal error: sentence count changed during tagging")
+    failures: list[int] = []
+    for item in tagged_sentences:
+        errors, _ = validate_tagged_sentence(item.original, item.tagged_text)
+        if errors:
+            failures.append(item.index)
+    if failures:
+        joined = ", ".join(str(index) for index in failures)
+        raise TaggingError(f"Could not produce a valid tag for sentence indexes: {joined}")
+
+    replacements = {item.index: item.tagged_text for item in tagged_sentences}
+    cursor = 0
+    rebuilt: list[str] = []
+    for sentence in spans:
+        rebuilt.append(text[cursor:sentence.start])
+        rebuilt.append(replacements[sentence.index])
+        cursor = sentence.end
+    rebuilt.append(text[cursor:])
+    tagged_text = "".join(rebuilt)
+
+    return {
+        "provider": "xai",
+        "mode_requested": selected_mode,
+        "sentence_count": len(spans),
+        "tagged_sentence_count": len(tagged_sentences),
+        "untagged_sentence_indexes": [],
+        "tagged_text": tagged_text,
+        "sentences": [
+            {
+                "index": item.index,
+                "original": item.original,
+                "tagged_text": item.tagged_text,
+                "tags": list(item.tags),
+                "source": item.source,
+                "warning": item.warning,
+            }
+            for item in tagged_sentences
+        ],
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Add at least one valid xAI speech tag to every sentence."
+    )
+    parser.add_argument("--text", help="Text to tag; defaults to stdin")
+    parser.add_argument("--language", default="auto")
+    parser.add_argument("--mode", choices=("auto", "llm", "deterministic"))
+    parser.add_argument("--format", choices=("text", "json"), default="json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        source_text = args.text if args.text is not None else sys.stdin.read()
+        result = tag_text(source_text, args.language, args.mode)
+    except TaggingError as exc:
+        print(f"xai-sentence-tagger: {exc}", file=sys.stderr)
+        return 1
+    if args.format == "text":
+        print(result["tagged_text"], end="")
+    else:
+        print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ai_tts_provider.py
+++ b/tests/test_ai_tts_provider.py
@@ -4,6 +4,7 @@ import base64
 import importlib.util
 import json
 import os
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -18,6 +19,7 @@ MODULE_PATH = (
 SPEC = importlib.util.spec_from_file_location("ai_tts_provider", MODULE_PATH)
 assert SPEC and SPEC.loader
 provider = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = provider
 SPEC.loader.exec_module(provider)
 
 
@@ -37,6 +39,26 @@ def wav_bytes() -> bytes:
         + b"data"
         + (0).to_bytes(4, "little")
     )
+
+
+def valid_tagging() -> dict:
+    return {
+        "sentence_count": 2,
+        "tagged_sentence_count": 2,
+        "untagged_sentence_indexes": [],
+        "annotations": [
+            {
+                "index": 0,
+                "original": "Hello.",
+                "tagged_text": "<soft>Hello.</soft>",
+            },
+            {
+                "index": 1,
+                "original": " Goodbye.",
+                "tagged_text": " <emphasis>Goodbye.</emphasis>",
+            },
+        ],
+    }
 
 
 class FakeResponse:
@@ -60,7 +82,7 @@ class ProviderBridgeTests(unittest.TestCase):
         with self.assertRaises(provider.BridgeError):
             provider.normalize_provider("unknown")
 
-    def test_google_payload_uses_provider_native_wav(self):
+    def test_google_payload_uses_provider_native_wav_and_annotations(self):
         with patch.dict(os.environ, {}, clear=True):
             payload = provider.build_process_payload(
                 "Hello.", provider="gemini", source_language="en"
@@ -72,6 +94,7 @@ class ProviderBridgeTests(unittest.TestCase):
         )
         self.assertEqual(payload["coverage_mode"], "natural")
         self.assertEqual(payload["tts_language"], "en")
+        self.assertIs(payload["include_annotations"], True)
 
     def test_xai_payload_uses_wav_for_voicemode(self):
         with patch.dict(
@@ -90,6 +113,30 @@ class ProviderBridgeTests(unittest.TestCase):
         self.assertEqual(payload["voice_id"], "EVE")
         self.assertEqual(payload["output_format"]["sample_rate"], 48000)
         self.assertEqual(payload["output_format"]["codec"], "wav")
+        self.assertIs(payload["include_annotations"], True)
+
+    def test_sentence_invariant_accepts_complete_annotations(self):
+        self.assertEqual(
+            provider.validate_sentence_tagging_response({"tagging": valid_tagging()}),
+            {"sentence_count": 2, "tagged_sentence_count": 2},
+        )
+
+    def test_sentence_invariant_rejects_missing_or_untagged_rows(self):
+        bad = valid_tagging()
+        bad["tagged_sentence_count"] = 1
+        bad["untagged_sentence_indexes"] = [1]
+        with self.assertRaisesRegex(provider.BridgeError, "invariant failed"):
+            provider.validate_sentence_tagging_response({"tagging": bad})
+
+        bad = valid_tagging()
+        bad["annotations"][1]["tagged_text"] = bad["annotations"][1]["original"]
+        with self.assertRaisesRegex(provider.BridgeError, "has no inserted speech tag"):
+            provider.validate_sentence_tagging_response({"tagging": bad})
+
+        bad = valid_tagging()
+        bad["annotations"] = bad["annotations"][:1]
+        with self.assertRaisesRegex(provider.BridgeError, "complete per-sentence"):
+            provider.validate_sentence_tagging_response({"tagging": bad})
 
     def test_rejects_non_wav_override(self):
         with patch.dict(os.environ, {"AI_TTS_CODEC": "mp3"}, clear=True):
@@ -156,6 +203,24 @@ class ProviderBridgeTests(unittest.TestCase):
         self.assertEqual(captured["timeout"], 9.0)
         self.assertEqual(captured["authorization"], "Bearer secret-token")
         self.assertEqual(captured["body"]["provider"], "google")
+
+    def test_synthesize_rejects_audio_if_sentence_proof_is_missing(self):
+        response = {
+            "tagging": {
+                "sentence_count": 1,
+                "tagged_sentence_count": 0,
+                "untagged_sentence_indexes": [0],
+                "annotations": [],
+            },
+            "audio_base64": base64.b64encode(wav_bytes()).decode(),
+            "audio_extension": "wav",
+            "media_type": "audio/wav",
+        }
+        with patch.dict(os.environ, {"AI_TTS_PROVIDER": "xai"}, clear=True), patch.object(
+            provider, "request_json", return_value=response
+        ):
+            with self.assertRaises(provider.BridgeError):
+                provider.synthesize("Hello.", "en", None)
 
 
 if __name__ == "__main__":

--- a/tests/test_tts_wrapper.py
+++ b/tests/test_tts_wrapper.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = ROOT / "service" / "tts.sh"
+TAGGER = ROOT / "service" / "xai_sentence_tagger.py"
+SPEC = importlib.util.spec_from_file_location("xai_sentence_tagger_for_wrapper", TAGGER)
+assert SPEC and SPEC.loader
+TAGGER_MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = TAGGER_MODULE
+SPEC.loader.exec_module(TAGGER_MODULE)
+
+
+class TTSWrapperTests(unittest.TestCase):
+    def _fixture(self, backend_exit: int = 1):
+        directory = tempfile.TemporaryDirectory()
+        root = Path(directory.name)
+        bin_dir = root / "bin"
+        bin_dir.mkdir()
+        payload_path = root / "payload.json"
+        backend_log = root / "backend.log"
+        curl_log = root / "curl.log"
+
+        backend = root / "tts_backends.sh"
+        backend.write_text(
+            "#!/usr/bin/env bash\n"
+            "printf '%s|%s\\n' \"${TTS_ENGINE:-}\" \"${XAI_API_KEY:-}\" > \"$BACKEND_LOG\"\n"
+            f"exit {backend_exit}\n",
+            encoding="utf-8",
+        )
+        backend.chmod(backend.stat().st_mode | stat.S_IXUSR)
+
+        curl = bin_dir / "curl"
+        curl.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, os, pathlib, sys\n"
+            "args=sys.argv[1:]\n"
+            "out=args[args.index('-o')+1]\n"
+            "data_arg=next(a for a in args if a.startswith('@'))\n"
+            "payload=json.loads(pathlib.Path(data_arg[1:]).read_text())\n"
+            "pathlib.Path(os.environ['PAYLOAD_PATH']).write_text(json.dumps(payload))\n"
+            "pathlib.Path(os.environ['CURL_LOG']).write_text('called')\n"
+            "wav=(b'RIFF'+(36).to_bytes(4,'little')+b'WAVE'+b'fmt '+"
+            "(16).to_bytes(4,'little')+(1).to_bytes(2,'little')+(1).to_bytes(2,'little')+"
+            "(48000).to_bytes(4,'little')+(96000).to_bytes(4,'little')+"
+            "(2).to_bytes(2,'little')+(16).to_bytes(2,'little')+b'data'+(0).to_bytes(4,'little'))\n"
+            "pathlib.Path(out).write_bytes(wav)\n"
+            "sys.stdout.write('200')\n",
+            encoding="utf-8",
+        )
+        curl.chmod(curl.stat().st_mode | stat.S_IXUSR)
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{bin_dir}:{env.get('PATH', '')}",
+                "TTS_BACKEND_SH": str(backend),
+                "TTS_SENTENCE_TAGGER_PY": str(TAGGER),
+                "TTS_NO_PLAY": "1",
+                "TTS_TAG_MODE": "deterministic",
+                "XAI_API_KEY": "test-key",
+                "PAYLOAD_PATH": str(payload_path),
+                "BACKEND_LOG": str(backend_log),
+                "CURL_LOG": str(curl_log),
+            }
+        )
+        return directory, root, env, payload_path, backend_log, curl_log
+
+    def test_direct_xai_tags_every_sentence_before_request(self):
+        fixture, _, env, payload_path, _, curl_log = self._fixture()
+        self.addCleanup(fixture.cleanup)
+        env["TTS_ENGINE"] = "xai"
+        completed = subprocess.run(
+            ["bash", str(WRAPPER), "Hello. Are you there?", "en"],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        output = Path(completed.stdout.strip())
+        self.assertTrue(output.is_file())
+        self.addCleanup(output.unlink, missing_ok=True)
+        payload = json.loads(payload_path.read_text())
+        spans = TAGGER_MODULE.sentence_spans("Hello. Are you there?")
+        self.assertEqual(len(spans), 2)
+        self.assertTrue(curl_log.is_file())
+        result = TAGGER_MODULE.tag_text("Hello. Are you there?", "en", "deterministic")
+        self.assertEqual(payload["text"], result["tagged_text"])
+        self.assertEqual(result["tagged_sentence_count"], result["sentence_count"])
+        for row in result["sentences"]:
+            errors, tags = TAGGER_MODULE.validate_tagged_sentence(
+                row["original"], row["tagged_text"]
+            )
+            self.assertEqual(errors, [])
+            self.assertGreaterEqual(len(tags), 1)
+
+    def test_selected_backend_cannot_use_raw_xai_fallback(self):
+        fixture, _, env, _, backend_log, curl_log = self._fixture(backend_exit=0)
+        self.addCleanup(fixture.cleanup)
+        env["TTS_ENGINE"] = "supertonic"
+        subprocess.run(
+            ["bash", str(WRAPPER), "Hello.", "en"],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        self.assertEqual(backend_log.read_text().strip(), "supertonic|")
+        self.assertFalse(curl_log.exists())
+
+    def test_failed_backend_falls_back_to_tagged_xai(self):
+        fixture, _, env, payload_path, backend_log, curl_log = self._fixture(backend_exit=1)
+        self.addCleanup(fixture.cleanup)
+        env["TTS_ENGINE"] = "supertonic"
+        completed = subprocess.run(
+            ["bash", str(WRAPPER), "One. Two!", "en"],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        output = Path(completed.stdout.strip())
+        self.assertTrue(output.is_file())
+        self.addCleanup(output.unlink, missing_ok=True)
+        self.assertEqual(backend_log.read_text().strip(), "supertonic|")
+        self.assertTrue(curl_log.is_file())
+        payload = json.loads(payload_path.read_text())
+        result = TAGGER_MODULE.tag_text("One. Two!", "en", "deterministic")
+        self.assertEqual(payload["text"], result["tagged_text"])
+        self.assertEqual(result["tagged_sentence_count"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tts_wrapper.py
+++ b/tests/test_tts_wrapper.py
@@ -138,6 +138,36 @@ class TTSWrapperTests(unittest.TestCase):
         self.assertEqual(payload["text"], result["tagged_text"])
         self.assertEqual(result["tagged_sentence_count"], 2)
 
+    def test_terminal_backend_errors_are_not_hidden_by_xai_fallback(self):
+        fixture, _, env, _, backend_log, curl_log = self._fixture(backend_exit=3)
+        self.addCleanup(fixture.cleanup)
+        env["TTS_ENGINE"] = "inworld"
+        completed = subprocess.run(
+            ["bash", str(WRAPPER), "Hello.", "en"],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 3)
+        self.assertEqual(backend_log.read_text().strip(), "inworld|")
+        self.assertFalse(curl_log.exists())
+
+    def test_unknown_engine_is_not_hidden_by_xai_fallback(self):
+        fixture, _, env, _, backend_log, curl_log = self._fixture(backend_exit=2)
+        self.addCleanup(fixture.cleanup)
+        env["TTS_ENGINE"] = "unknown"
+        completed = subprocess.run(
+            ["bash", str(WRAPPER), "Hello.", "en"],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 2)
+        self.assertEqual(backend_log.read_text().strip(), "unknown|")
+        self.assertFalse(curl_log.exists())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_xai_sentence_tagger.py
+++ b/tests/test_xai_sentence_tagger.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "service" / "xai_sentence_tagger.py"
+SPEC = importlib.util.spec_from_file_location("xai_sentence_tagger", MODULE_PATH)
+assert SPEC and SPEC.loader
+module = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = module
+SPEC.loader.exec_module(module)
+
+
+class FakeResponse:
+    def __init__(self, payload: dict):
+        self._payload = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return None
+
+    def read(self):
+        return self._payload
+
+
+class SentenceTaggerTests(unittest.TestCase):
+    def test_deterministic_mode_tags_every_sentence_and_preserves_source(self):
+        text = "Hello.\n\nAre you there? ¡Sí!"
+        result = module.tag_text(text, "en", "deterministic")
+        self.assertEqual(result["sentence_count"], 3)
+        self.assertEqual(result["tagged_sentence_count"], 3)
+        self.assertEqual(result["untagged_sentence_indexes"], [])
+        self.assertEqual(len(result["sentences"]), 3)
+        for row in result["sentences"]:
+            errors, tags = module.validate_tagged_sentence(row["original"], row["tagged_text"])
+            self.assertEqual(errors, [])
+            self.assertGreaterEqual(len(tags), 1)
+            self.assertNotEqual(row["original"], row["tagged_text"])
+
+    def test_preserves_abbreviation_as_one_sentence(self):
+        spans = module.sentence_spans("Dr. Smith arrived. He waved.")
+        self.assertEqual([span.text for span in spans], ["Dr. Smith arrived.", " He waved."])
+
+    def test_llm_valid_rows_are_used_and_invalid_rows_are_repaired(self):
+        response = {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps(
+                            {
+                                "sentences": [
+                                    {"index": 0, "tagged_text": "<soft>Hello.</soft>"},
+                                    {"index": 1, "tagged_text": "Rewritten sentence."},
+                                ]
+                            }
+                        )
+                    }
+                }
+            ]
+        }
+
+        def fake_urlopen(req, timeout):
+            return FakeResponse(response)
+
+        env = {
+            "TTS_TAGGER_URL": "http://127.0.0.1:12434/v1",
+            "TTS_TAGGER_MODEL": "local-model",
+            "TTS_TAGGER_API_KEY": "not-needed",
+        }
+        with patch.dict(os.environ, env, clear=True), patch.object(
+            module.urllib_request, "urlopen", fake_urlopen
+        ):
+            result = module.tag_text("Hello. Goodbye.", "en", "llm")
+
+        self.assertEqual(result["sentences"][0]["source"], "llm")
+        self.assertEqual(result["sentences"][1]["source"], "deterministic")
+        self.assertEqual(result["tagged_sentence_count"], 2)
+        for row in result["sentences"]:
+            errors, _ = module.validate_tagged_sentence(row["original"], row["tagged_text"])
+            self.assertEqual(errors, [])
+
+    def test_auto_mode_falls_back_when_llm_is_not_configured(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = module.tag_text("One. Two.", "en", "auto")
+        self.assertEqual(result["tagged_sentence_count"], 2)
+        self.assertTrue(all(row["source"] == "deterministic" for row in result["sentences"]))
+
+    def test_rejects_unknown_mode_and_blank_text(self):
+        with self.assertRaises(module.TaggingError):
+            module.tag_text("Hello.", mode="off")
+        with self.assertRaises(module.TaggingError):
+            module.tag_text("   ", mode="deterministic")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- convert `service/tts.sh` into a provider-safety wrapper and retain the existing multi-backend implementation as `service/tts_backends.sh`
- make every direct and fallback xAI request pass through a strict sentence-by-sentence xAI tagger
- prevent the historical dispatcher from reaching raw xAI by clearing `XAI_API_KEY` while ordinary backends run
- add optional OpenAI-compatible local-LLM direction with deterministic repair for every missing, invalid, or source-rewriting sentence
- validate an explicit N/N sentence proof before constructing the xAI request
- update the AI Sentence Tagger / AI Voice Studio bridge to request complete annotations and reject returned audio when any sentence lacks direction
- preserve terminal backend errors: unknown engines and explicit Inworld credential refusals are not hidden by xAI fallback
- install the wrapper, backend dispatcher, and tagger together across supported Unix agent skill locations
- document configuration, routing, fallback, security, and validation behavior

## Staged commits

1. `feat: tag every sentence before xAI synthesis`
2. `test: verify sentence tags before every xAI request`
3. `fix: preserve terminal backend failures`
4. `docs: document mandatory xAI sentence tagging`

## Validation

No GitHub Actions were used as a release gate.

- 20 deterministic Local VoiceMode tests passed locally
- five wrapper integration tests inspect direct xAI, ordinary backend isolation, tagged xAI fallback, unknown-engine exit 2, and terminal credential exit 3
- five direct sentence-tagger tests cover multi-sentence preservation, abbreviations, valid LLM rows, invalid-row repair, deterministic fallback, and invalid modes
- ten companion-bridge tests cover annotation requests, N/N proof validation, duplicate/missing rows, strict base64/RIFF handling, atomic writes, bearer authentication, and rejection before audio write
- `python -m compileall -q service integrations tests` passed
- `bash -n` passed for the wrapper, installer integration, and bridge scripts
- focused core invariant tests in the companion repositories passed separately
- remote branch is ahead of `main` with no divergence

## Runtime guarantee

A provider request is allowed only after the wrapper receives:

```json
{
  "sentence_count": 2,
  "tagged_sentence_count": 2,
  "untagged_sentence_indexes": []
}
```

and verifies one indexed, source-preserving tagged row per sentence. Otherwise the operation fails before xAI is contacted.

## Platform boundary

The built-in mandatory xAI wrapper and `TTS_SH` companion bridge are wired into Unix/macOS `talk.sh`. Windows continues to use its separate PowerShell dispatcher and is not silently claimed as changed by this PR.